### PR TITLE
Fix broken link to Contact Us page

### DIFF
--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -42,7 +42,9 @@
                 <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
                 <p class="govuk-body">Try again later.</p>
                 <p class="govuk-body">
-                    <a class="govuk-link" href="#">Contact us</a> if you need assistance.
+                    <a class="govuk-footer__link" href="/help">
+                        Contact Us
+                    </a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
#### Reason for change
Link to Contact Us page is broken on error screen

#### Steps to Test
CI

**review**:
@Arelle/arelle
