### PR TITLE
Remove utility> for closing of div

### DIFF
--- a/src/main/resources/templates/survey.html
+++ b/src/main/resources/templates/survey.html
@@ -98,7 +98,7 @@
                         <div class="govuk-radios__item" th:each="rating, iter : ${T(com.frc.codex.model.Rating).values()}">
                             <input class="govuk-radios__input" type="radio" th:field="${surveyRequest.searchSpeedRating}" th:value="${rating.getValue()}">
                             <label class="govuk-label govuk-radios__label" th:for="'searchSpeedRating' + ${iter.index + 1}" th:text="${rating.getLabel()}"></label>
-                        Utility>
+                        </div>
                     </div>
                 </fieldset>
             </div>


### PR DESCRIPTION
#### Reason for change
`utility>` is appearing at the end of all answers for the speed question on the survey.

#### Description of change
Remove the `utility>` text and add appropriate closing div

#### Steps to Test
CI

**review**:
@Arelle/arelle
