### PR TITLE
Support action: Get Companies House indexing statistics

### DIFF
--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -36,6 +36,10 @@ curl $CURL_OPTS http://localhost:8080/admin/smoketest/queue
 echo "Test database page"
 curl $CURL_OPTS http://localhost:8080/admin/smoketest/database
 
+echo "Test support action: get_ch_indexing_stats"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"get_ch_indexing_stats"}'
+
 echo "Test support action: list_errors"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"list_errors"}'

--- a/support/actions/get_ch_indexing_stats_action.py
+++ b/support/actions/get_ch_indexing_stats_action.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+from support.actions.base_action import BaseAction
+
+
+class GetChIndexingStatsAction(BaseAction):
+
+    def _run(self, options, cursor) -> tuple[bool, str, Any]:
+        query = "SELECT " \
+            "(SELECT COUNT(*) FROM ch_archives WHERE completed_date IS NULL) AS incomplete_archives, " \
+            "(SELECT COUNT(*) FROM ch_archives) AS total_archives, " \
+            "(SELECT MAX(completed_date) FROM ch_archives) AS latest_archive_completed, " \
+            "(SELECT COUNT(*) FROM companies WHERE completed_date IS NULL) AS incomplete_companies, " \
+            "(SELECT COUNT(*) FROM companies) AS total_companies, " \
+            "(SELECT MAX(completed_date) FROM companies) AS latest_company_completed "
+        cursor.execute(query)
+        column_names = [desc[0] for desc in cursor.description]
+        first_row = cursor.fetchone()
+        stats = dict(zip(column_names, first_row))
+        stats = {
+            k: str(v) for k, v in stats.items()
+        }
+        message = "Companies House indexing statistics retrieved."
+        return True, message, stats

--- a/support/lambda_function.py
+++ b/support/lambda_function.py
@@ -1,12 +1,14 @@
 import json
 import logging
 
+from support.actions.get_ch_indexing_stats_action import GetChIndexingStatsAction
 from support.actions.list_errors_action import ListErrorsAction
 from support.actions.reset_filings_action import ResetFilingsAction
 
 logger = logging.getLogger(__name__)
 
 ACTIONS_MAP = {
+    'get_ch_indexing_stats': GetChIndexingStatsAction,
     'list_errors': ListErrorsAction,
     'reset_filings': ResetFilingsAction,
 }


### PR DESCRIPTION
#### Reason for change
There's no easy way to get information about CH indexing progress without a database connection.

#### Description of change
Add a support action that returns statistics about CH archive and company indexing progress.

#### Steps to Test
Added smoke test to CI

**review**:
@Arelle/arelle
