### PR TITLE
Implement indexer job that generates filings from CSV input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _HTTP_CACHE
 bin
 build
 dev/compose-local.yml
+dev/indexer_uploads/*.csv
 dev/logs
 dev/taxonomy_packages/*.zip
 frc-codex-server.secrets

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -96,6 +96,16 @@ Resources:
       Tags:
       - Key: "Environment"
         Value: !Ref EnvironmentName
+  S3IndexerUploadsBucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !Sub "${EnvironmentName}-codex-indexer-uploads"
+      AccessControl: "Private"
+      VersioningConfiguration:
+        Status: "Enabled"
+      Tags:
+        - Key: "Environment"
+          Value: !Ref EnvironmentName
   S3TaxonomyPackagesBucket:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -106,6 +116,23 @@ Resources:
       Tags:
       - Key: "Environment"
         Value: !Ref EnvironmentName
+  IAMPolicyReadIndexerUploadsBucket:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub "${EnvironmentName}CodexReadIndexerUploadsBucket"
+      Path: "/"
+      Description: !Sub "Permission for read-only actions on the S3 bucket ${S3IndexerUploadsBucket}."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Resource:
+              - !Sub "${S3IndexerUploadsBucket.Arn}"
+              - !Sub "${S3IndexerUploadsBucket.Arn}/*"
+            Action:
+              - "s3:Describe*"
+              - "s3:Get*"
+              - "s3:List*"
+            Effect: "Allow"
   IAMPolicyReadResultsBucket:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -329,6 +356,8 @@ Resources:
           Value: !Ref S3TaxonomyPackagesBucket
         - Name: "SQS_JOBS_QUEUE_NAME"
           Value: unused
+        - Name: "S3_INDEXER_UPLOADS_BUCKET_NAME"
+          Value: !Ref S3IndexerUploadsBucket
         - Name: "S3_RESULTS_BUCKET_NAME"
           Value: !Ref S3ResultsBucket
         - Name: "SQS_RESULTS_QUEUE_NAME"

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -28,6 +28,7 @@ services:
       FCA_DATA_API_BASE_URL: "https://data.fca.org.uk/artefacts/"
       FCA_SEARCH_API_URL: "https://api.data.fca.org.uk/search?index=fca-nsm-searchdata"
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8180,suspend=n"
+      S3_INDEXER_UPLOADS_BUCKET_NAME: "frc-codex-indexer-uploads"
       S3_RESULTS_BUCKET_NAME: "frc-codex-results"
       SQS_JOBS_QUEUE_NAME: "frc_codex_jobs"
       SQS_RESULTS_QUEUE_NAME: "frc_codex_results"
@@ -121,6 +122,7 @@ services:
     environment:
       REGION_NAME: 'eu-west-2'
       S3_HTTP_CACHE_BUCKET_NAME: 'frc-codex-http-cache'
+      S3_INDEXER_UPLOADS_BUCKET_NAME: "frc-codex-indexer-uploads"
       S3_RESULTS_BUCKET_NAME: 'frc-codex-results'
       S3_TAXONOMY_PACKAGES_BUCKET_NAME: 'frc-codex-taxonomy-packages'
       SUPPORT_EMAIL: 'dev@localhost'
@@ -131,6 +133,7 @@ services:
         aliases:
           - localstack.localhost
     volumes:
+      - ./indexer_uploads:/tmp/indexer_uploads
       - ./localstack.sh:/etc/localstack/init/ready.d/script.sh
       - ./taxonomy_packages:/tmp/taxonomy_packages
   postgres:

--- a/dev/localstack.sh
+++ b/dev/localstack.sh
@@ -9,6 +9,8 @@ awslocal sqs create-queue --queue-name frc_codex_results --region "$REGION_NAME"
 # Create S3 Bucket
 echo "Initializing localstack S3 bucket: $S3_HTTP_CACHE_BUCKET_NAME"
 awslocal s3 mb "s3://$S3_HTTP_CACHE_BUCKET_NAME" --region "$REGION_NAME"
+echo "Initializing localstack S3 bucket: $S3_INDEXER_UPLOADS_BUCKET_NAME"
+awslocal s3 mb "s3://$S3_INDEXER_UPLOADS_BUCKET_NAME" --region "$REGION_NAME"
 echo "Initializing localstack S3 bucket: $S3_RESULTS_BUCKET_NAME"
 awslocal s3 mb "s3://$S3_RESULTS_BUCKET_NAME" --region "$REGION_NAME"
 echo "Initializing localstack S3 bucket: $S3_TAXONOMY_PACKAGES_BUCKET_NAME"
@@ -19,3 +21,7 @@ echo "Initializing taxonomy packages in bucket: $S3_TAXONOMY_PACKAGES_BUCKET_NAM
 awslocal s3 sync --exclude "*" --include "*.zip" \
   "/tmp/taxonomy_packages" \
   "s3://$S3_TAXONOMY_PACKAGES_BUCKET_NAME"
+echo "Initializing indexer uploads in bucket: $S3_INDEXER_UPLOADS_BUCKET_NAME"
+awslocal s3 sync --exclude "*" --include "*.csv" \
+  "/tmp/indexer_uploads" \
+  "s3://$S3_INDEXER_UPLOADS_BUCKET_NAME"

--- a/src/main/java/com/frc/codex/indexer/UploadIndexer.java
+++ b/src/main/java/com/frc/codex/indexer/UploadIndexer.java
@@ -1,0 +1,5 @@
+package com.frc.codex.indexer;
+
+public interface UploadIndexer extends IndexerJob {
+
+}

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -29,6 +29,7 @@ public interface FilingIndexProperties {
 	boolean isDbMigrateAsync();
 	int lambdaPreprocessingConcurrency();
 	long maximumSearchResults();
+	String s3IndexerUploadsBucketName();
 	String s3ResultsBucketName();
 	long searchPageSize();
 	String sqsJobsQueueName();

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -44,6 +44,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String FILING_LIMIT_FCA = "FILING_LIMIT_FCA";
 	private static final String LAMBDA_PREPROCESSING_CONCURRENCY = "LAMBDA_PREPROCESSING_CONCURRENCY";
 	private static final String MAXIMUM_SEARCH_RESULTS = "MAXIMUM_SEARCH_RESULTS";
+	private static final String S3_INDEXER_UPLOADS_BUCKET_NAME = "S3_INDEXER_UPLOADS_BUCKET_NAME";
 	private static final String S3_RESULTS_BUCKET_NAME = "S3_RESULTS_BUCKET_NAME";
 	private static final String SEARCH_PAGE_SIZE = "SEARCH_PAGE_SIZE";
 	private static final String SECRETS_FILEPATH = "/run/secrets/frc-codex-server.secrets";
@@ -77,6 +78,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final long awsLambdaTimeoutSeconds;
 	private final int lambdaPreprocessingConcurrency;
 	private final long maximumSearchResults;
+	private final String s3IndexerUploadsBucketName;
 	private final String s3ResultsBucketName;
 	private final long searchPageSize;
 	private final String sqsJobsQueueName;
@@ -126,6 +128,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		maximumSearchResults = Long.parseLong(requireNonNull(getEnv(MAXIMUM_SEARCH_RESULTS, "100")));
 		searchPageSize = Long.parseLong(requireNonNull(getEnv(SEARCH_PAGE_SIZE, "10")));
 
+		s3IndexerUploadsBucketName = requireNonNull(getEnv(S3_INDEXER_UPLOADS_BUCKET_NAME));
 		s3ResultsBucketName = requireNonNull(getEnv(S3_RESULTS_BUCKET_NAME));
 		sqsJobsQueueName = requireNonNull(getEnv(SQS_JOBS_QUEUE_NAME));
 		sqsResultsQueueName = requireNonNull(getEnv(SQS_RESULTS_QUEUE_NAME));
@@ -301,6 +304,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public long maximumSearchResults() {
 		return maximumSearchResults;
+	}
+
+	public String s3IndexerUploadsBucketName() {
+		return s3IndexerUploadsBucketName;
 	}
 
 	public String s3ResultsBucketName() {

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -126,6 +126,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return "frc-codex-results";
 	}
 
+	public String s3IndexerUploadsBucketName() {
+		return "frc-codex-indexer-uploads";
+	}
+
 	public long searchPageSize() {
 		return 10;
 	}


### PR DESCRIPTION
#### Reason for change
For initial population of the index, as well as general use in the future, it would be valuable to be able to bulk upload entries into the index without needing direct database access.

#### Description of change
Create an indexer job that downloads CSV files of predetermined format from a dedicated S3 bucket, inserts each row as an index entry, then deletes the file from the S3 bucket if the entire file has been processed.

Note: The CSV upload indexer circumvents the CH and FCA filing limit settings.

#### Steps to Test
Test locally, add CSV (
[split_test.csv](https://github.com/user-attachments/files/18738033/split_test.csv)
) to your project at `/dev/indexer_uploads/*`. This will automatically be processed by the indexer. Confirm corresponding records are created and the viewer and assets can be generated. Confirm that the uploaded file is removed from the bucket afterwards.

**review**:
@Arelle/arelle
