### PR TITLE
Add inlineXbrlDocumentSet plugin for multi-target support

### DIFF
--- a/processor/main/workers/ixbrl_viewer_worker.py
+++ b/processor/main/workers/ixbrl_viewer_worker.py
@@ -121,7 +121,7 @@ class IxbrlViewerWorker(Worker):
                 'viewerURL': '/ixbrlviewer.js',
                 'viewer_feature_mandatory_facts': 'companies-house'
             },
-            plugins="ixbrl-viewer|saveLoadableOIM",
+            plugins="inlineXbrlDocumentSet|ixbrl-viewer|saveLoadableOIM",
         )
         with Session() as session:
             success = session.run(runtime_options)

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">CODEx Admin</a></h1>
     <a href="/admin/logout" data-i18n="admin:index.logout">Log Out</a>

--- a/src/main/resources/templates/admin/smoketest/companieshouse/company.html
+++ b/src/main/resources/templates/admin/smoketest/companieshouse/company.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <table>

--- a/src/main/resources/templates/admin/smoketest/companieshouse/history.html
+++ b/src/main/resources/templates/admin/smoketest/companieshouse/history.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <h2 data-i18n="admin:coho.history.header">Companies House Bulk Downloads</h2>

--- a/src/main/resources/templates/admin/smoketest/companieshouse/stream.html
+++ b/src/main/resources/templates/admin/smoketest/companieshouse/stream.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <table>

--- a/src/main/resources/templates/admin/smoketest/database.html
+++ b/src/main/resources/templates/admin/smoketest/database.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <h3 data-i18n="admin:database.unprocessed">Unprocessed Filings</h3>

--- a/src/main/resources/templates/admin/smoketest/fca.html
+++ b/src/main/resources/templates/admin/smoketest/fca.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <h3> <span data-i18n="admin:fca.header">FCA Filings Since</span> <span th:text="(${sinceDate})"></span></h3>

--- a/src/main/resources/templates/admin/smoketest/indexer.html
+++ b/src/main/resources/templates/admin/smoketest/indexer.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <h3 data-i18n="admin:indexer.status">Indexer Status</h3>

--- a/src/main/resources/templates/admin/smoketest/queue.html
+++ b/src/main/resources/templates/admin/smoketest/queue.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body>
-<header th:replace="fragments :: header"></header>
+<header th:replace="~{fragments :: header}"></header>
 <div class="admin-container">
     <h1><a href="/" data-i18n="admin:home">UK iXBRL Viewer</a></h1>
     <h3 data-i18n="admin:queue.header">Queue Status</h3>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
         <div class="govuk-grid-row">
@@ -20,8 +20,8 @@
         </div>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
         <div class="govuk-grid-row">
@@ -23,8 +23,8 @@
         </div>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/help.html
+++ b/src/main/resources/templates/help.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (~{ :: title})">
+<head th:replace="~{fragments :: head (~{ :: title})}">
     <title data-i18n="help:title">Contact Us - UK iXBRL Viewer</title>
 </head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
-    <div th:replace="fragments :: banner-beta"></div>
+    <div th:replace="~{fragments :: banner-beta}"></div>
     <main class="govuk-main-wrapper">
         <h1 class="govuk-heading-l" id="main-content" data-i18n="help:contactUs">Contact Us</h1>
         <div th:if="${success == true}" class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
@@ -51,8 +51,8 @@
         </p>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
-    <div th:replace="fragments :: banner-beta"></div>
+    <div th:replace="~{fragments :: banner-beta}"></div>
     <main class="govuk-main-wrapper">
         <details class="govuk-details">
             <summary class="govuk-details__summary">
@@ -245,8 +245,8 @@ The UK iXBRL Viewer, funded by the UK's Regulators' Pioneer Fund (Department for
         </div>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 <script>
     sessionStorage.removeItem('ixbrl-viewer-home-link-query');
     let query = window.location.search;

--- a/src/main/resources/templates/survey.html
+++ b/src/main/resources/templates/survey.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (~{ :: title})">
+<head th:replace="~{fragments :: head (~{ :: title})}">
     <title data-i18n="survey:title">Survey - UK iXBRL Viewer</title>
 </head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
-    <div th:replace="fragments :: banner-beta"></div>
+    <div th:replace="~{fragments :: banner-beta}"></div>
     <main class="govuk-main-wrapper">
         <h1 class="govuk-heading-l" id="main-content" data-i18n="survey:header">Customer Satisfaction Survey</h1>
         <div id="success-banner" class="govuk-notification-banner govuk-notification-banner--success"
@@ -86,8 +86,8 @@
         </form>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 <script th:if="${success == true}">
     localStorage.setItem("survey_submitted_date", new Date().toString());
 </script>

--- a/src/main/resources/templates/view/loading.html
+++ b/src/main/resources/templates/view/loading.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (~{ :: title})">
+<head th:replace="~{fragments :: head (~{ :: title})}">
     <title data-i18n="loading:title">Loading viewer...</title>
 </head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="loading-bar">
     <div>
         <img src="/icons/loading.svg" alt="Loading icon"/>

--- a/src/main/resources/templates/view/unavailable.html
+++ b/src/main/resources/templates/view/unavailable.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head th:replace="fragments :: head (_)"></head>
+<head th:replace="~{fragments :: head (_)}"></head>
 <body class="govuk-template__body">
-<script th:replace="fragments :: script-govuk-frontend-supported"></script>
-<a th:replace="fragments :: link-skip-to-main"></a>
-<header th:replace="fragments :: header"></header>
+<script th:replace="~{fragments :: script-govuk-frontend-supported}"></script>
+<a th:replace="~{fragments :: link-skip-to-main}"></a>
+<header th:replace="~{fragments :: header}"></header>
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
         <div class="govuk-grid-row">
@@ -18,8 +18,8 @@
         </div>
     </main>
 </div>
-<footer th:replace="fragments :: footer-main"></footer>
-<script th:replace="fragments :: script-govuk-frontend"></script>
+<footer th:replace="~{fragments :: footer-main}"></footer>
+<script th:replace="~{fragments :: script-govuk-frontend}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
#### Reason for change
* inlineXbrlDocumentSet plugin is required for multi-target support.
* Unwrapped expressions are deprecated and will be removed in a future version of thymeleaf.

#### Description of change
* Enable inlineXbrlDocumentSet plugin.
* Update thymeleaf syntax.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
