### PR TITLE
Capture dependency versions used during generation

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -729,6 +729,7 @@ Resources:
           S3_HTTP_CACHE_BUCKET_NAME: !Ref S3HttpCacheBucket
           S3_RESULTS_BUCKET_NAME: !Ref S3ResultsBucket
           S3_TAXONOMY_PACKAGES_BUCKET_NAME: !Ref S3TaxonomyPackagesBucket
+          SERVICE_VERSION: !Ref Version
       EphemeralStorage:
         Size: 512
       LoggingConfig:

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -54,6 +54,7 @@ services:
       S3_RESULTS_BUCKET_NAME: 'frc-codex-results'
       S3_TAXONOMY_PACKAGES_BUCKET_NAME: 'frc-codex-taxonomy-packages'
       S3_REGION_NAME: 'eu-west-2'
+      SERVICE_VERSION: 'v0.0'
     platform: linux/amd64
     ports:
       - 8081:8080

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -18,6 +18,9 @@ def lambda_handler(event, context):
     )
     worker_result = processor.run_from_lambda(event, context)
     result = {
+        'ArelleVersion': processor_options.arelle_version,
+        'ArelleViewerVersion': processor_options.ixbrl_viewer_version,
+        'ServiceVersion': processor_options.service_version,
         'CompanyName': worker_result.company_name,
         'CompanyNumber': worker_result.company_number,
         'Error': worker_result.error,

--- a/processor/main/main_queue_manager.py
+++ b/processor/main/main_queue_manager.py
@@ -1,14 +1,14 @@
 import json
 import logging
-from typing import Iterable
+from collections.abc import Iterable
 
 import boto3
 from botocore.exceptions import ClientError
 
 from processor.base.job_message import JobMessage
+from processor.base.queue_manager import QueueManager
 from processor.base.worker import WorkerResult
 from processor.processor_options import ProcessorOptions
-from processor.base.queue_manager import QueueManager
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,9 @@ class MainQueueManager(QueueManager):
         self._results_queue = MainQueueManager._get_queue(processor_options.sqs_results_queue_name, processor_options)
         self._max_number = processor_options.sqs_max_messages
         self._wait_time = processor_options.sqs_wait_time
+        self._arelle_version = processor_options.arelle_version
+        self._ixbrl_viewer_version = processor_options.ixbrl_viewer_version
+        self._service_version = processor_options.service_version
 
     def complete_job(self, job_message: JobMessage) -> None:
         self._jobs_queue.delete_messages(
@@ -72,6 +75,21 @@ class MainQueueManager(QueueManager):
                 'DataType': 'String'
             },
         }
+        if self._arelle_version:
+            message_attributes['ArelleVersion'] = {
+                'StringValue': self._arelle_version,
+                'DataType': 'String'
+            }
+        if self._ixbrl_viewer_version:
+            message_attributes['ArelleViewerVersion'] = {
+                'StringValue': self._ixbrl_viewer_version,
+                'DataType': 'String'
+            }
+        if self._service_version:
+            message_attributes['ServiceVersion'] = {
+                'StringValue': self._service_version,
+                'DataType': 'String'
+            }
         if worker_result.company_name:
             message_attributes['CompanyName'] = {
                 'StringValue': worker_result.company_name,

--- a/processor/main/main_queue_manager.py
+++ b/processor/main/main_queue_manager.py
@@ -65,79 +65,30 @@ class MainQueueManager(QueueManager):
             raise error
 
     def publish_result(self, worker_result: WorkerResult) -> None:
-        message_attributes = {
-            'FilingId': {
-                'StringValue': worker_result.filing_id,
-                'DataType': 'String'
-            },
-            'Success': {
-                'StringValue': 'true' if worker_result.success else 'false',
-                'DataType': 'String'
-            },
+        message_body = {
+            'ArelleVersion': self._arelle_version,
+            'ArelleViewerVersion': self._ixbrl_viewer_version,
+            'ServiceVersion': self._service_version,
+            'CompanyName': worker_result.company_name,
+            'CompanyNumber': worker_result.company_number,
+            'Error': worker_result.error,
+            'FilingId': worker_result.filing_id,
+            'Logs': worker_result.logs,
+            'Success': worker_result.success,
+            "Filename": worker_result.filename,
+            'ViewerEntrypoint': worker_result.viewer_entrypoint,
+            'OimDirectory': worker_result.oim_directory,
+            # Analytics
+            'DownloadTime': worker_result.download_time,
+            'TotalProcessingTime': worker_result.total_processing_time,
+            'TotalUploadedBytes': worker_result.total_uploaded_bytes,
+            'UploadTime': worker_result.upload_time,
+            'WorkerTime': worker_result.worker_time,
         }
-        if self._arelle_version:
-            message_attributes['ArelleVersion'] = {
-                'StringValue': self._arelle_version,
-                'DataType': 'String'
-            }
-        if self._ixbrl_viewer_version:
-            message_attributes['ArelleViewerVersion'] = {
-                'StringValue': self._ixbrl_viewer_version,
-                'DataType': 'String'
-            }
-        if self._service_version:
-            message_attributes['ServiceVersion'] = {
-                'StringValue': self._service_version,
-                'DataType': 'String'
-            }
-        if worker_result.company_name:
-            message_attributes['CompanyName'] = {
-                'StringValue': worker_result.company_name,
-                'DataType': 'String'
-            }
-        if worker_result.company_number:
-            message_attributes['CompanyNumber'] = {
-                'StringValue': worker_result.company_number,
-                'DataType': 'String'
-            }
-        if worker_result.document_date:
-            message_attributes['DocumentDate'] = {
-                'StringValue': worker_result.document_date.strftime('%Y-%m-%d'),
-                'DataType': 'String'
-            }
-        if worker_result.error:
-            message_attributes['Error'] = {
-                'StringValue': worker_result.error,
-                'DataType': 'String'
-            }
-        message_attributes['Analytics'] = {
-            'StringValue': json.dumps({
-                'download_time': worker_result.download_time,
-                'total_processing_time': worker_result.total_processing_time,
-                'total_uploaded_bytes': worker_result.total_uploaded_bytes,
-                'upload_time': worker_result.upload_time,
-                'worker_time': worker_result.worker_time,
-            }),
-            'DataType': 'String'
-        }
-        if worker_result.filename:
-            message_attributes['Filename'] = {
-                'StringValue': worker_result.filename,
-                'DataType': 'String'
-            }
-        if worker_result.viewer_entrypoint:
-            message_attributes['ViewerEntrypoint'] = {
-                'StringValue': worker_result.viewer_entrypoint,
-                'DataType': 'String'
-            }
-        if worker_result.oim_directory:
-            message_attributes['OimDirectory'] = {
-                'StringValue': worker_result.oim_directory,
-                'DataType': 'String'
-            }
+        if worker_result.document_date is not None:
+            message_body['DocumentDate'] = worker_result.document_date.strftime('%Y-%m-%d')
         self._results_queue.send_message(
-            MessageBody=worker_result.logs,
-            MessageAttributes=message_attributes
+            MessageBody=json.dumps(message_body),
         )
 
     @staticmethod

--- a/processor/processor_options.py
+++ b/processor/processor_options.py
@@ -1,9 +1,21 @@
 import os
 from functools import cached_property
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 
+def _get_library_version(library_name: str) -> str | None:
+    try:
+        return version(library_name)
+    except PackageNotFoundError:
+        return None
+
+
 class ProcessorOptions:
+
+    @cached_property
+    def arelle_version(self) -> str | None:
+        return _get_library_version('arelle-release')
 
     @cached_property
     def aws_endpoint_url(self):
@@ -12,6 +24,10 @@ class ProcessorOptions:
     @cached_property
     def http_cache_directory(self) -> Path:
         return Path(os.getenv('HTTP_CACHE_DIRECTORY', '/tmp/_HTTP_CACHE'))
+
+    @cached_property
+    def ixbrl_viewer_version(self) -> str | None:
+        return _get_library_version('ixbrl-viewer')
 
     @cached_property
     def maximum_processors(self):
@@ -32,6 +48,10 @@ class ProcessorOptions:
     @cached_property
     def s3_region_name(self):
         return os.getenv('S3_REGION_NAME')
+
+    @cached_property
+    def service_version(self) -> str | None:
+        return os.getenv('SERVICE_VERSION')
 
     @cached_property
     def sqs_jobs_queue_name(self):

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -38,6 +38,7 @@ import com.frc.codex.model.Company;
 import com.frc.codex.model.Filing;
 import com.frc.codex.model.FilingResultRequest;
 import com.frc.codex.model.FilingStatus;
+import com.frc.codex.model.GenerationVersioning;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.SearchFilingsRequest;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
@@ -82,6 +83,9 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 					"download_time = ?, " +
 					"upload_time = ?, " +
 					"worker_time = ?, " +
+					"generation_arelle_version = ?," +
+					"generation_ixbrl_viewer_version = ?," +
+					"generation_service_version = ?," +
 					"total_processing_time = ?, " +
 					"total_uploaded_bytes = ?, " +
 					"result_timestamp = CURRENT_TIMESTAMP " +
@@ -104,6 +108,15 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 			statement.setDouble(++i, filingResultRequest.getDownloadTime());
 			statement.setDouble(++i, filingResultRequest.getUploadTime());
 			statement.setDouble(++i, filingResultRequest.getWorkerTime());
+			if (filingResultRequest.getGenerationVersioning() == null) {
+				statement.setNull(++i, java.sql.Types.VARCHAR);
+				statement.setNull(++i, java.sql.Types.VARCHAR);
+				statement.setNull(++i, java.sql.Types.VARCHAR);
+			} else {
+				statement.setString(++i, filingResultRequest.getGenerationVersioning().getArelleVersion());
+				statement.setString(++i, filingResultRequest.getGenerationVersioning().getViewerVersion());
+				statement.setString(++i, filingResultRequest.getGenerationVersioning().getServiceVersion());
+			}
 			statement.setDouble(++i, filingResultRequest.getTotalProcessingTime());
 			statement.setLong(++i, filingResultRequest.getTotalUploadedBytes());
 			statement.setObject(++i, filingResultRequest.getFilingId());
@@ -562,6 +575,11 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 					.streamTimepoint(resultSet.getLong("stream_timepoint"))
 					.oimDirectory(resultSet.getString("oim_directory"))
 					.stubViewerUrl(resultSet.getString("stub_viewer_url"))
+					.generationVersioning(GenerationVersioning.builder()
+						.arelleVersion(resultSet.getString("generation_arelle_version"))
+						.viewerVersion(resultSet.getString("generation_ixbrl_viewer_version"))
+						.serviceVersion(resultSet.getString("generation_service_version"))
+						.build())
 					.build());
 		}
 		return results.build();

--- a/src/main/java/com/frc/codex/model/Filing.java
+++ b/src/main/java/com/frc/codex/model/Filing.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 public class Filing {
 	private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
 	private final UUID filingId;
 	private final Timestamp discoveredDate;
 	private final String status;
@@ -26,6 +27,7 @@ public class Filing {
 	private final String logs;
 	private final String stubViewerUrl;
 	private final String oimDirectory;
+	private final GenerationVersioning generationVersioning;
 
 	public Filing(Builder b) {
 		this.filingId = b.filingId;
@@ -46,6 +48,7 @@ public class Filing {
 		this.logs = b.logs;
 		this.stubViewerUrl = b.stubViewerUrl;
 		this.oimDirectory = b.oimDirectory;
+		this.generationVersioning = b.generationVersioning;
 	}
 
 	public String displayDocumentDate() {
@@ -169,6 +172,10 @@ public class Filing {
 		}
 	}
 
+	public GenerationVersioning getGenerationVersioning() {
+		return generationVersioning;
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -192,6 +199,7 @@ public class Filing {
 		private String logs;
 		private String stubViewerUrl;
 		private String oimDirectory;
+		private GenerationVersioning generationVersioning;
 
 		public Filing build() {
 			return new Filing(this);
@@ -285,6 +293,11 @@ public class Filing {
 
 		public Builder oimDirectory(String oimDirectory) {
 			this.oimDirectory = oimDirectory;
+			return this;
+		}
+
+		public Builder generationVersioning(GenerationVersioning generationVersioning) {
+			this.generationVersioning = generationVersioning;
 			return this;
 		}
 	}

--- a/src/main/java/com/frc/codex/model/FilingResultRequest.java
+++ b/src/main/java/com/frc/codex/model/FilingResultRequest.java
@@ -25,6 +25,7 @@ public class FilingResultRequest {
 	private final Long totalUploadedBytes;
 	private final Double uploadTime;
 	private final Double workerTime;
+	private final GenerationVersioning generationVersioning;
 
 	private FilingResultRequest(Builder builder) {
 		this.companyName = builder.companyName;
@@ -42,6 +43,7 @@ public class FilingResultRequest {
 		this.totalUploadedBytes = builder.totalUploadedBytes;
 		this.uploadTime = builder.uploadTime;
 		this.workerTime = builder.workerTime;
+		this.generationVersioning = builder.generationVersioning;
 	}
 
 	public static Builder builder() {
@@ -108,6 +110,10 @@ public class FilingResultRequest {
 		return workerTime;
 	}
 
+	public GenerationVersioning getGenerationVersioning() {
+		return generationVersioning;
+	}
+
 	public boolean isSuccess() {
 		return success;
 	}
@@ -128,6 +134,7 @@ public class FilingResultRequest {
 		private Long totalUploadedBytes;
 		private Double uploadTime;
 		private Double workerTime;
+		private GenerationVersioning generationVersioning;
 
 		public Builder companyName(String companyName) {
 			this.companyName = companyName;
@@ -177,12 +184,18 @@ public class FilingResultRequest {
 			String filename = null;
 			String oimDirectory = null;
 			String viewerEntrypoint = null;
+			GenerationVersioning generationVersioning = null;
 			if (!success) {
 				error = jsonNode.get("Error").asText();
 			} else {
 				filename = jsonNode.get("Filename").asText();
 				oimDirectory = jsonNode.get("OimDirectory").asText(null);
 				viewerEntrypoint = jsonNode.get("ViewerEntrypoint").asText();
+				generationVersioning = GenerationVersioning.builder()
+						.arelleVersion(jsonNode.get("ArelleVersion").asText(null))
+						.viewerVersion(jsonNode.get("ArelleViewerVersion").asText(null))
+						.serviceVersion(jsonNode.get("ServiceVersion").asText(null))
+						.build();
 			}
 			String companyName = jsonNode.get("CompanyName").asText();
 			companyName = companyName == null ? null : companyName.toUpperCase();
@@ -209,6 +222,7 @@ public class FilingResultRequest {
 					.filename(filename)
 					.oimDirectory(oimDirectory)
 					.stubViewerUrl(viewerEntrypoint)
+					.generationVersioning(generationVersioning)
 					.success(success);
 		}
 
@@ -229,6 +243,11 @@ public class FilingResultRequest {
 
 		public Builder stubViewerUrl(String stubViewerUrl) {
 			this.stubViewerUrl = stubViewerUrl;
+			return this;
+		}
+
+		public Builder generationVersioning(GenerationVersioning generationVersioning) {
+			this.generationVersioning = generationVersioning;
 			return this;
 		}
 

--- a/src/main/java/com/frc/codex/model/GenerationVersioning.java
+++ b/src/main/java/com/frc/codex/model/GenerationVersioning.java
@@ -1,0 +1,55 @@
+package com.frc.codex.model;
+
+public class GenerationVersioning {
+    private final String arelleVersion;
+    private final String viewerVersion;
+    private final String serviceVersion;
+
+    public GenerationVersioning(Builder b) {
+        this.arelleVersion = b.arelleVersion;
+        this.viewerVersion = b.viewerVersion;
+        this.serviceVersion = b.serviceVersion;
+    }
+
+    public String getArelleVersion() {
+        return arelleVersion;
+    }
+
+    public String getViewerVersion() {
+        return viewerVersion;
+    }
+
+    public String getServiceVersion() {
+        return serviceVersion;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String arelleVersion;
+        private String viewerVersion;
+        private String serviceVersion;
+
+        public GenerationVersioning build() {
+            return new GenerationVersioning(this);
+        }
+
+        public Builder arelleVersion(String arelleVersion) {
+            this.arelleVersion = arelleVersion;
+            return this;
+        }
+
+        public Builder viewerVersion(String viewerVersion) {
+            this.viewerVersion = viewerVersion;
+            return this;
+        }
+
+        public Builder serviceVersion(String serviceVersion) {
+            this.serviceVersion = serviceVersion;
+            return this;
+        }
+    }
+}

--- a/src/main/resources/db/migration/V10__viewer_generation_version.sql
+++ b/src/main/resources/db/migration/V10__viewer_generation_version.sql
@@ -1,0 +1,9 @@
+-- Capture dependency versions used to generate viewer and OIM artifacts for potential future resets.
+ALTER TABLE filings
+    ADD COLUMN generation_arelle_version VARCHAR(20),
+    ADD COLUMN generation_ixbrl_viewer_version VARCHAR(20),
+    ADD COLUMN generation_service_version VARCHAR(20);
+
+CREATE INDEX generation_arelle_version_idx ON filings (generation_arelle_version);
+CREATE INDEX generation_ixbrl_viewer_version_idx ON filings (generation_ixbrl_viewer_version);
+CREATE INDEX generation_service_version_idx ON filings (generation_service_version);


### PR DESCRIPTION
#### Reason for change
We should record the versions of Arelle, the Arelle Viewer, and the CODEx service itself that are used to generate a viewer and OIM artifacts so that if a broken version of one of these is ever deployed we can selectively reset generations.

#### Description of change
* Record versions to DB for:
  * Arelle Python dependency
  * Arelle iXBRL Viewer Python dependency
  * The version of the CODEx processor used by lambda

#### Steps to Test
* Use the new cloud formation template in dev.
* Deploy the updated service.
* Generate a new viewer.
* Check that filing in DB includes dependency versions.

**review**:
@Arelle/arelle
