### PR TITLE
Separate capturing and processing of stream events

### DIFF
--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -40,6 +40,10 @@ echo "Test support action: get_ch_indexing_stats"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"get_ch_indexing_stats"}'
 
+echo "Test support action: get_ch_streaming_stats"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"get_ch_streaming_stats"}'
+
 echo "Test support action: list_errors"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"list_errors"}'
@@ -55,3 +59,8 @@ curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
 echo "Test support action: reset_filings"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_filings","company_number":"1234567890"}'
+
+echo "Test support action: reset_stream_events"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"reset_stream_events","timepoint_before":0}'
+

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -63,4 +63,3 @@ curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
 echo "Test support action: reset_stream_events"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"reset_stream_events","timepoint_before":0}'
-

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseClient.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseClient.java
@@ -15,5 +15,6 @@ public interface CompaniesHouseClient {
 	List<NewFilingRequest> getCompanyFilings(String companyNumber, String companyName) throws JsonProcessingException;
 	Set<String> getCompanyFilingUrls(String companyNumber, String filingId) throws JsonProcessingException;
 	boolean isEnabled();
-	void streamFilings(Long timepoint, Function<CompaniesHouseFiling, Boolean> callback) throws IOException;
+	CompaniesHouseFiling parseStreamedFiling(String json) throws JsonProcessingException;
+	void streamFilings(Long timepoint, Function<String, Boolean> callback) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseCompaniesIndexer.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseCompaniesIndexer.java
@@ -1,0 +1,7 @@
+package com.frc.codex.clients.companieshouse;
+
+import com.frc.codex.indexer.IndexerJob;
+
+public interface CompaniesHouseCompaniesIndexer extends IndexerJob {
+
+}

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamIndexer.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamIndexer.java
@@ -1,0 +1,7 @@
+package com.frc.codex.clients.companieshouse;
+
+import com.frc.codex.indexer.IndexerJob;
+
+public interface CompaniesHouseStreamIndexer extends IndexerJob {
+
+}

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamListener.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseStreamListener.java
@@ -1,0 +1,7 @@
+package com.frc.codex.clients.companieshouse;
+
+import com.frc.codex.indexer.IndexerJob;
+
+public interface CompaniesHouseStreamListener extends IndexerJob {
+
+}

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
@@ -292,19 +292,13 @@ public class CompaniesHouseClientImpl implements CompaniesHouseClient {
 		return enabled;
 	}
 
-	public void streamFilings(Long timepoint, Function<CompaniesHouseFiling, Boolean> callback) throws IOException {
+	public void streamFilings(Long timepoint, Function<String, Boolean> callback) throws IOException {
 		Function<String, Boolean> parseCallback = json -> {
 			if (json == null || json.length() <= 1) {
 				// The stream emits blank "heartbeat" lines.
 				return true;
 			}
-			CompaniesHouseFiling filing;
-			try {
-				filing = parseStreamedFiling(json);
-			} catch (JsonProcessingException e) {
-				throw new RuntimeException(e);
-			}
-			return callback.apply(filing);
+			return callback.apply(json);
 		};
 		throwExceptionIfDisabled();
 		stream.streamFilings(timepoint, parseCallback);

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseCompaniesIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseCompaniesIndexerImpl.java
@@ -8,16 +8,18 @@ import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+import com.frc.codex.clients.companieshouse.CompaniesHouseCompaniesIndexer;
 import com.frc.codex.database.DatabaseManager;
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseCompany;
 import com.frc.codex.clients.companieshouse.RateLimitException;
-import com.frc.codex.indexer.IndexerJob;
 import com.frc.codex.model.Company;
 import com.frc.codex.model.NewFilingRequest;
 
-public class CompaniesHouseCompaniesIndexerImpl implements IndexerJob {
+@Component
+public class CompaniesHouseCompaniesIndexerImpl implements CompaniesHouseCompaniesIndexer {
 	private static final int COMPANIES_BATCH_SIZE = 100;
 	private static final Logger LOG = LoggerFactory.getLogger(CompaniesHouseCompaniesIndexerImpl.class);
 	private final CompaniesHouseClient companiesHouseClient;

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -8,20 +8,22 @@ import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseCompany;
 import com.frc.codex.clients.companieshouse.CompaniesHouseFiling;
+import com.frc.codex.clients.companieshouse.CompaniesHouseStreamIndexer;
 import com.frc.codex.clients.companieshouse.RateLimitException;
 import com.frc.codex.database.DatabaseManager;
-import com.frc.codex.indexer.IndexerJob;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.RegistryCode;
 import com.frc.codex.model.StreamEvent;
 import com.frc.codex.properties.FilingIndexProperties;
 
-public class CompaniesHouseStreamIndexerImpl implements IndexerJob {
+@Component
+public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamIndexer {
 	private static final Logger LOG = LoggerFactory.getLogger(CompaniesHouseStreamIndexerImpl.class);
 	private final CompaniesHouseClient companiesHouseClient;
 	private final long companiesHouseStreamIndexerBatchSize;

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
@@ -9,13 +9,15 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
+import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
 import com.frc.codex.clients.companieshouse.RateLimitException;
 import com.frc.codex.database.DatabaseManager;
-import com.frc.codex.indexer.IndexerJob;
 
-public class CompaniesHouseStreamListenerImpl implements IndexerJob {
+@Component
+public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamListener {
 	private static final Logger LOG = LoggerFactory.getLogger(CompaniesHouseStreamListenerImpl.class);
 	private final CompaniesHouseClient companiesHouseClient;
 	private final DatabaseManager databaseManager;

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
@@ -1,0 +1,75 @@
+package com.frc.codex.clients.companieshouse.impl;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
+import com.frc.codex.clients.companieshouse.RateLimitException;
+import com.frc.codex.database.DatabaseManager;
+import com.frc.codex.indexer.IndexerJob;
+
+public class CompaniesHouseStreamListenerImpl implements IndexerJob {
+	private static final Logger LOG = LoggerFactory.getLogger(CompaniesHouseStreamListenerImpl.class);
+	private final CompaniesHouseClient companiesHouseClient;
+	private final DatabaseManager databaseManager;
+	private int companiesHouseSessionEventCount;
+	private Date companiesHouseStreamLastOpenedDate;
+	private final Pattern timepointPattern;
+
+	public CompaniesHouseStreamListenerImpl(
+			CompaniesHouseClient companiesHouseClient,
+			DatabaseManager databaseManager
+	) {
+		this.companiesHouseClient = companiesHouseClient;
+		this.databaseManager = databaseManager;
+		this.timepointPattern = Pattern.compile("\"timepoint\":(\\d+)");
+	}
+
+	public String getStatus() {
+		return String.format("""
+						Companies House Stream Listener:
+						\tStream last opened: %s
+						\tEvents discovered this session: %s""",
+				companiesHouseStreamLastOpenedDate,
+				companiesHouseSessionEventCount
+		);
+	}
+
+	public boolean isHealthy() {
+		return companiesHouseStreamLastOpenedDate != null;
+	}
+
+	public void run(Supplier<Boolean> continueCallback) {
+		if (!continueCallback.get()) {
+			return;
+		}
+		LOG.info("Starting Companies House stream listener at {}", System.currentTimeMillis() / 1000);
+		Function<String, Boolean> callback = (String json) -> {
+			Matcher matcher = timepointPattern.matcher(json);
+			if (!matcher.find()) {
+				LOG.warn("Timepoint pattern did not match stream event JSON: {}", json);
+				return false;
+			}
+			long timepoint = Long.parseLong(matcher.group(1));
+			databaseManager.createStreamEvent(timepoint, json);
+			companiesHouseSessionEventCount++;
+			return true; // Continue streaming
+		};
+		long startTimepoint = databaseManager.getLatestStreamTimepoint(null);
+		companiesHouseStreamLastOpenedDate = new Date();
+		try {
+			companiesHouseClient.streamFilings(startTimepoint, callback);
+		} catch (RateLimitException e) {
+			LOG.warn("Rate limit exceeded while streaming CH filings. Resuming later.", e);
+		} catch (IOException | InterruptedException e) {
+			LOG.error("Companies House stream closed with an exception.", e);
+		}
+	}
+}

--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -12,6 +12,7 @@ import com.frc.codex.model.FilingResultRequest;
 import com.frc.codex.model.FilingStatus;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.SearchFilingsRequest;
+import com.frc.codex.model.StreamEvent;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
 
 public interface DatabaseManager {
@@ -22,6 +23,8 @@ public interface DatabaseManager {
 	boolean companyNumberExists(String companyNumber);
 	String createCompaniesHouseArchive(CompaniesHouseArchive archive);
 	UUID createFiling(NewFilingRequest newFilingRequest);
+	UUID createStreamEvent(long timepoint, String json);
+	void deleteStreamEvent(UUID streamEventId);
 	boolean filingExists(String registryCode, String externalFilingId);
 	Filing getFiling(UUID filingId);
 	List<Filing> getFilingsByStatus(FilingStatus status);
@@ -30,6 +33,7 @@ public interface DatabaseManager {
 	Long getLatestStreamTimepoint(Long defaultTimepoint);
 	long getRegistryCount(RegistryCode registryCode);
 	void resetCompany(String companyNumber);
+	List<StreamEvent> getStreamEvents(long limit);
 	void resetFiling(UUID filingId);
 	List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest);
 	void updateFilingStatus(UUID filingId, String status);

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -312,6 +312,13 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 			if (resultSet.next()) {
 				return resultSet.getLong(1);
 			}
+			statement = connection.prepareStatement(
+					"SELECT MAX(stream_timepoint) FROM filings"
+			);
+			resultSet = statement.executeQuery();
+			if (resultSet.next()) {
+				return resultSet.getLong(1);
+			}
 			return defaultTimepoint;
 		} catch (SQLException e) {
 			throw new RuntimeException(e);

--- a/src/main/java/com/frc/codex/model/StreamEvent.java
+++ b/src/main/java/com/frc/codex/model/StreamEvent.java
@@ -1,0 +1,57 @@
+package com.frc.codex.model;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+public class StreamEvent {
+	private final UUID streamEventId;
+	private final Timestamp createdDate;
+	private final String json;
+
+	public StreamEvent(Builder b) {
+		this.streamEventId = b.streamEventId;
+		this.createdDate = b.createdDate;
+		this.json = b.json;
+	}
+
+	public UUID getStreamEventId() {
+		return streamEventId;
+	}
+
+	public Timestamp getCreatedDate() {
+		return createdDate;
+	}
+
+	public String getJson() {
+		return json;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+		private UUID streamEventId;
+		private Timestamp createdDate;
+		private String json;
+
+		public StreamEvent build() {
+			return new StreamEvent(this);
+		}
+
+		public Builder streamEventId(String streamEventId) {
+			this.streamEventId = UUID.fromString(streamEventId);
+			return this;
+		}
+
+		public Builder createdDate(Timestamp createdDate) {
+			this.createdDate = createdDate;
+			return this;
+		}
+
+		public Builder json(String json) {
+			this.json = json;
+			return this;
+		}
+	}
+}

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -15,6 +15,7 @@ public interface FilingIndexProperties {
 	String companiesHouseRestApiKey();
 	String companiesHouseStreamApiBaseUrl();
 	String companiesHouseStreamApiKey();
+	long companiesHouseStreamIndexerBatchSize();
 	String dbSeedScriptPath();
 	String fcaDataApiBaseUrl();
 	int fcaPastDays();

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -28,6 +28,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String COMPANIES_HOUSE_REST_API_KEY = "COMPANIES_HOUSE_REST_API_KEY";
 	private static final String COMPANIES_HOUSE_STREAM_API_BASE_URL = "COMPANIES_HOUSE_STREAM_API_BASE_URL";
 	private static final String COMPANIES_HOUSE_STREAM_API_KEY = "COMPANIES_HOUSE_STREAM_API_KEY";
+	private static final String COMPANIES_HOUSE_STREAM_INDEXER_BATCH_SIZE = "COMPANIES_HOUSE_STREAM_INDEXER_BATCH_SIZE";
 	private static final String HTTP_USERNAME = "HTTP_USERNAME";
 	private static final String HTTP_PASSWORD = "HTTP_PASSWORD";
 	private static final String DB_URL = "DB_URL";
@@ -62,6 +63,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String companiesHouseRestApiKey;
 	private final String companiesHouseStreamApiBaseUrl;
 	private final String companiesHouseStreamApiKey;
+	private final long companiesHouseStreamIndexerBatchSize;
 	private final String dbUrl;
 	private final String dbUsername;
 	private final String dbPassword;
@@ -104,6 +106,8 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		// Default rapid rate limit is 20 requests per 10 seconds (600 requests / 5 minutes)
 		companiesHouseRapidRateLimit = Integer.parseInt(requireNonNull(getEnv(COMPANIES_HOUSE_RAPID_RATE_LIMIT, "20")));
 		companiesHouseRapidRateWindow = Integer.parseInt(requireNonNull(getEnv(COMPANIES_HOUSE_RAPID_RATE_WINDOW, "10000")));
+
+		companiesHouseStreamIndexerBatchSize = Long.parseLong(requireNonNull(getEnv(COMPANIES_HOUSE_STREAM_INDEXER_BATCH_SIZE, "100")));
 
 		dbUrl = requireNonNull(getEnv(DB_URL));
 		dbUsername = requireNonNull(getEnv(DB_USERNAME));
@@ -239,6 +243,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String companiesHouseStreamApiKey() {
 		return companiesHouseStreamApiKey;
+	}
+
+	public long companiesHouseStreamIndexerBatchSize() {
+		return companiesHouseStreamIndexerBatchSize;
 	}
 
 	public String dbSeedScriptPath() {

--- a/src/main/resources/db/migration/V9__stream_events.sql
+++ b/src/main/resources/db/migration/V9__stream_events.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS stream_events (
+    stream_event_id uuid NOT NULL DEFAULT gen_random_uuid(),
+    created_date TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    timepoint BIGINT NOT NULL,
+    json TEXT NOT NULL,
+    PRIMARY KEY (stream_event_id)
+);

--- a/src/main/resources/db/migration/V9__stream_events.sql
+++ b/src/main/resources/db/migration/V9__stream_events.sql
@@ -5,3 +5,4 @@ CREATE TABLE IF NOT EXISTS stream_events (
     json TEXT NOT NULL,
     PRIMARY KEY (stream_event_id)
 );
+CREATE INDEX stream_events_timepoint_idx ON stream_events (timepoint);

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -16,6 +16,7 @@ import com.frc.codex.model.FilingResultRequest;
 import com.frc.codex.model.FilingStatus;
 import com.frc.codex.model.NewFilingRequest;
 import com.frc.codex.model.SearchFilingsRequest;
+import com.frc.codex.model.StreamEvent;
 import com.frc.codex.model.companieshouse.CompaniesHouseArchive;
 
 @Component
@@ -49,6 +50,14 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 		return null;
 	}
 
+	public UUID createStreamEvent(long timepoint, String json) {
+		return null;
+	}
+
+	public void deleteStreamEvent(UUID streamEventId) {
+
+	}
+
 	public boolean filingExists(String registryCode, String externalFilingId) {
 		return false;
 	}
@@ -79,17 +88,15 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 
 	public void resetCompany(String companyNumber) { }
 
+	public List<StreamEvent> getStreamEvents(long limit) {
+		return null;
+	}
+
 	public void resetFiling(UUID filingId) { }
 
 	public List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest) {
 		return List.of();
 	}
-
-	private Filing.Builder copyFiling(UUID filingId) {
-		return Filing.builder();
-	}
-
-	private void updateFiling(Filing filing) {}
 
 	public void updateFilingStatus(UUID filingId, String status) { }
 

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -58,6 +58,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return "XXX";
 	}
 
+	public long companiesHouseStreamIndexerBatchSize() {
+		return 100;
+	}
+
 	public String dbSeedScriptPath() {
 		return null;
 	}

--- a/support/actions/base_action.py
+++ b/support/actions/base_action.py
@@ -27,3 +27,12 @@ class BaseAction(ABC):
                 cursor.close()
         finally:
             connection.close()
+
+    @staticmethod
+    def collect_stats(cursor):
+        column_names = [desc[0] for desc in cursor.description]
+        first_row = cursor.fetchone()
+        stats = dict(zip(column_names, first_row))
+        return {
+            k: str(v) for k, v in stats.items()
+        }

--- a/support/actions/get_ch_indexing_stats_action.py
+++ b/support/actions/get_ch_indexing_stats_action.py
@@ -14,11 +14,6 @@ class GetChIndexingStatsAction(BaseAction):
             "(SELECT COUNT(*) FROM companies) AS total_companies, " \
             "(SELECT MAX(completed_date) FROM companies) AS latest_company_completed "
         cursor.execute(query)
-        column_names = [desc[0] for desc in cursor.description]
-        first_row = cursor.fetchone()
-        stats = dict(zip(column_names, first_row))
-        stats = {
-            k: str(v) for k, v in stats.items()
-        }
+        stats = BaseAction.collect_stats(cursor)
         message = "Companies House indexing statistics retrieved."
         return True, message, stats

--- a/support/actions/get_ch_streaming_stats_action.py
+++ b/support/actions/get_ch_streaming_stats_action.py
@@ -1,0 +1,17 @@
+from support.actions.base_action import BaseAction
+
+
+class GetChStreamingStatsAction(BaseAction):
+
+    def _run(self, options, cursor) -> tuple[bool, str, list | int]:
+        query = "SELECT " \
+                "COUNT(*) AS unprocessed_count, " \
+                "MIN(created_date) AS earliest_created_date, " \
+                "MIN(timepoint) AS earliest_timepoint, " \
+                "MAX(created_date) AS latest_created_date, " \
+                "MAX(timepoint) AS latest_timepoint " \
+                "FROM stream_events"
+        cursor.execute(query)
+        stats = BaseAction.collect_stats(cursor)
+        message = "Companies House streaming statistics retrieved."
+        return True, message, stats

--- a/support/actions/reset_stream_events_action.py
+++ b/support/actions/reset_stream_events_action.py
@@ -1,0 +1,38 @@
+from support.actions.base_action import BaseAction
+
+
+class ResetStreamEventsAction(BaseAction):
+
+    def _run(self, options, cursor) -> tuple[bool, str, list | int]:
+        params = []
+        conditions = []
+        notes = []
+        if 'created_after' not in options and \
+                'created_before' not in options and \
+                'timepoint_after' not in options and \
+                'timepoint_before' not in options:
+            return False, "Must provide at least one of 'created_after', " \
+                          "'created_before', 'timepoint_after', or " \
+                          "'timepoint_before'.", 0
+        if options.get('created_after'):
+            conditions.append("created_date >= %s")
+            params.append(options['created_after'])
+            notes.append(f"Creation date is after {options['created_after']}.")
+        if options.get('created_before'):
+            conditions.append("created_date < %s")
+            params.append(options['created_before'])
+            notes.append(f"Creation date is before {options['created_before']}.")
+        if options.get('timepoint_after'):
+            conditions.append("timepoint >= %s")
+            params.append(options['timepoint_after'])
+            notes.append(f"Timepoint is after {options['timepoint_after']}.")
+        if options.get('timepoint_before'):
+            conditions.append("timepoint < %s")
+            params.append(options['timepoint_before'])
+            notes.append(f"Timepoint is before {options['timepoint_before']}.")
+
+        query = "DELETE FROM stream_events WHERE " + " AND ".join(conditions) + ';'
+        cursor.execute(query, tuple(params))
+        rows_affected = cursor.rowcount
+        message = f"Deleted {rows_affected} stream events with the following filter(s): " + ' '.join(notes)
+        return True, message, rows_affected

--- a/support/lambda_function.py
+++ b/support/lambda_function.py
@@ -2,19 +2,23 @@ import json
 import logging
 
 from support.actions.get_ch_indexing_stats_action import GetChIndexingStatsAction
+from support.actions.get_ch_streaming_stats_action import GetChStreamingStatsAction
 from support.actions.list_errors_action import ListErrorsAction
 from support.actions.reset_archives_action import ResetArchivesAction
 from support.actions.reset_companies_action import ResetCompaniesAction
 from support.actions.reset_filings_action import ResetFilingsAction
+from support.actions.reset_stream_events_action import ResetStreamEventsAction
 
 logger = logging.getLogger(__name__)
 
 ACTIONS_MAP = {
     'get_ch_indexing_stats': GetChIndexingStatsAction,
+    'get_ch_streaming_stats': GetChStreamingStatsAction,
     'list_errors': ListErrorsAction,
     'reset_archives': ResetArchivesAction,
     'reset_companies': ResetCompaniesAction,
     'reset_filings': ResetFilingsAction,
+    'reset_stream_events': ResetStreamEventsAction
 }
 
 


### PR DESCRIPTION
#### Reason for change
Primarily to better manage and persist processing of stream events

Additionally, we currently run the risk of [taking too long to consume stream events](https://developer-specs.company-information.service.gov.uk/streaming-api/guides/overview#timepoints). If rate limiting causes a long delay while processing a stream event, or if enough stream events are logged in a short period of time (which will happen whenever we perform a stream catchup), it could cause 416 rejection.

#### Description of change
Two separate indexer tasks:
- A listener that simply consumes stream events and stores them in the database
- An indexer that retrieves stream events from the database, processes them, then deletes them

Added a couple of support actions to assist with managing stream events in the database.

#### Steps to Test
Run locally and monitor with the `get_ch_streaming_stats` support action:
```
curl -XPOST "http://localhost:8082/2015-03-31/functions/function/invocations" -d '{"action": "get_ch_streaming_stats"}'
```
The count should fluctuate as events are saved by the listener before being removed by the indexer.

**review**:
@Arelle/arelle
