### PR TITLE
Reset companies found in daily uploads

### DIFF
--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -29,6 +29,7 @@ public interface DatabaseManager {
 	LocalDateTime getLatestFcaFilingDate(LocalDateTime defaultDate);
 	Long getLatestStreamTimepoint(Long defaultTimepoint);
 	long getRegistryCount(RegistryCode registryCode);
+	void resetCompany(String companyNumber);
 	void resetFiling(UUID filingId);
 	List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest);
 	void updateFilingStatus(UUID filingId, String status);

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -528,6 +528,22 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		}
 	}
 
+	public void resetCompany(String companyNumber) {
+		try (Connection connection = getInitializedConnection(false)) {
+			String sql = "UPDATE companies SET completed_date = NULL " +
+					"WHERE company_number = ?";
+			PreparedStatement statement = connection.prepareStatement(sql);
+			statement.setObject(1, companyNumber);
+			int affectedRows = statement.executeUpdate();
+			if (affectedRows == 0) {
+				throw new SQLException("Resetting company failed, no rows affected.");
+			}
+			connection.commit();
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	public void resetFiling(UUID filingId) {
 		try (Connection connection = getInitializedConnection(false)) {
 			String sql = "UPDATE filings SET " +

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -32,6 +32,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.frc.codex.indexer.UploadIndexer;
+import com.frc.codex.model.ArchiveType;
 import com.frc.codex.properties.FilingIndexProperties;
 import com.frc.codex.model.RegistryCode;
 import com.frc.codex.database.DatabaseManager;
@@ -169,7 +170,7 @@ public class IndexerImpl implements Indexer {
 	 * extracting company numbers from the contained filenames.
 	 * Returns true if the archive was processed successfully or doesn't need processing.
 	 */
-	private boolean processCompaniesHouseArchive(URI uri, String archiveType, Set<String> existingCompanyNumbers) {
+	private boolean processCompaniesHouseArchive(URI uri, ArchiveType archiveType, Set<String> existingCompanyNumbers) {
 		if (databaseManager.checkCompaniesLimit(properties.unprocessedCompaniesLimit())) {
 			return false;
 		}
@@ -193,7 +194,7 @@ public class IndexerImpl implements Indexer {
 		}
 	}
 
-	private boolean processCompaniesHouseArchiveUsingTempFile(URI uri, String archiveType, String filename, Path tempFile, Set<String> existingCompanyNumbers) {
+	private boolean processCompaniesHouseArchiveUsingTempFile(URI uri, ArchiveType archiveType, String filename, Path tempFile, Set<String> existingCompanyNumbers) {
 		boolean completed = true;
 		LOG.info("Downloading archive: {}", uri);
 		try {
@@ -240,7 +241,7 @@ public class IndexerImpl implements Indexer {
 			CompaniesHouseArchive archive = CompaniesHouseArchive.builder()
 					.filename(filename)
 					.uri(uri)
-					.archiveType(archiveType)
+					.archiveType(archiveType.getCode())
 					.build();
 			databaseManager.createCompaniesHouseArchive(archive);
 			LOG.info("Completed archive: {}", filename);
@@ -259,19 +260,19 @@ public class IndexerImpl implements Indexer {
 		List<URI> downloadLinks;
 		downloadLinks = companiesHouseHistoryClient.getDailyDownloadLinks();
 		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, "daily", existingCompanyNumbers)) {
+			if (!processCompaniesHouseArchive(uri, ArchiveType.DAILY, existingCompanyNumbers)) {
 				return;
 			}
 		}
 		downloadLinks = companiesHouseHistoryClient.getMonthlyDownloadLinks();
 		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, "monthly", existingCompanyNumbers)) {
+			if (!processCompaniesHouseArchive(uri, ArchiveType.MONTHLY, existingCompanyNumbers)) {
 				return;
 			}
 		}
 		downloadLinks = companiesHouseHistoryClient.getArchiveDownloadLinks();
 		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, "archive", existingCompanyNumbers)) {
+			if (!processCompaniesHouseArchive(uri, ArchiveType.ARCHIVE, existingCompanyNumbers)) {
 				return;
 			}
 		}

--- a/src/main/java/com/frc/codex/model/ArchiveType.java
+++ b/src/main/java/com/frc/codex/model/ArchiveType.java
@@ -1,0 +1,24 @@
+package com.frc.codex.model;
+
+public enum ArchiveType {
+	ARCHIVE ("archive", false),
+	DAILY ("daily", true),
+	MONTHLY ("monthly", false);
+
+	private final String code;
+	private final boolean resetsCompany;
+
+
+	private ArchiveType(String code, boolean resetsCompany) {
+		this.code = code;
+		this.resetsCompany = resetsCompany;
+	}
+
+	public String getCode() {
+		return this.code;
+	}
+
+	public boolean isResetsCompany() {
+		return this.resetsCompany;
+	}
+}

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -77,6 +77,8 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 		return 0;
 	}
 
+	public void resetCompany(String companyNumber) { }
+
 	public void resetFiling(UUID filingId) { }
 
 	public List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest) {


### PR DESCRIPTION
#### Reason for change
Gaps in stream processing may lead to filings being missed. One possible mitigation is using data from the CH daily archive uploads to trigger re-loading of potentially missed filings.

#### Description of change
If a filing with a company number and document date does not match a filing that we've indexed, reset the company in the companies index so we can load any new filings from the company.

#### Steps to Test
Trigger downloading of recent daily archive upload.
If your environment has already processed all of them, reset one:
```
curl -XPOST "http://localhost:8082/2015-03-31/functions/function/invocations" -d '{"action": "reset_archives", "filename": "Accounts_Bulk_Data-2025-02-19.zip"}'
```

**review**:
@Arelle/arelle
