### PR TITLE
Remove UK's from beta header

### DIFF
--- a/src/main/resources/i18n/en/fragments.json
+++ b/src/main/resources/i18n/en/fragments.json
@@ -2,7 +2,7 @@
   "accessibilityStatement": "Accessibility Statement",
   "beta": {
     "header": "Beta",
-    "intro": "This is a new service funded by the UK's Regulators' Pioneer Fund (Department for Science, Innovation and Technology) – your",
+    "intro": "This is a new service funded by the Regulators' Pioneer Fund (Department for Science, Innovation and Technology) – your",
     "link": "feedback",
     "outro": "will help us to improve it."
   },


### PR DESCRIPTION
#### Reason for change
In order to trim the English version of the Beta header down to one line, remove the `UK's` from the header.

#### Steps to Test
CI

**review**:
@Arelle/arelle
