### PR TITLE
Increase lambda ephemeral storage for large filings

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -731,7 +731,7 @@ Resources:
           S3_TAXONOMY_PACKAGES_BUCKET_NAME: !Ref S3TaxonomyPackagesBucket
           SERVICE_VERSION: !Ref Version
       EphemeralStorage:
-        Size: 512
+        Size: 1024
       LoggingConfig:
         LogFormat: "Text"
         LogGroup: !Sub "/aws/lambda/${EnvironmentName}-processor"


### PR DESCRIPTION
#### Reason for change
A few large filings (250MB HTML docs) have run into storage space limitations in lambda. Increasing storage space allowed them to complete:
`An unexpected error occurred while processing the filing: [Errno 28] No space left on device: '/tmp/ixbrl-viewer_*`

#### Description of change
Increase lambda processor ephemeral storage to 1 GB. Cost increase is < $1 per year.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
