### PR TITLE
Add ability to paginate searches, get total result count

### DIFF
--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -29,6 +29,7 @@ public interface DatabaseManager {
 	Filing getFiling(UUID filingId);
 	List<Filing> getFilingsByStatus(FilingStatus status);
 	List<Filing> getFilingsByStatus(FilingStatus status, RegistryCode registryCode);
+	long getFilingsCount(SearchFilingsRequest searchFilingsRequest);
 	LocalDateTime getLatestFcaFilingDate(LocalDateTime defaultDate);
 	Long getLatestStreamTimepoint(Long defaultTimepoint);
 	long getRegistryCount(RegistryCode registryCode);

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -718,10 +718,13 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 			}
 		};
 		if (!StringUtils.isEmpty(companyName)) {
-			for (String part : companyName.split("\\s+")) {
-				conditions.add("UPPER(company_name) LIKE UPPER(?)");
-				parameters.add("%" + part.trim() + "%");
+			if (!count) {
+				selects.add("ts_rank(to_tsvector('english', company_name), query) as rank");
+				orderBys.add(0, "rank DESC");
 			}
+			queries.add("websearch_to_tsquery('english', ?) query");
+			conditions.add("to_tsvector('english', company_name) @@ query");
+			parameters.add(companyName);
 		}
 		if (!StringUtils.isEmpty(companyNumber)) {
 			conditions.add("company_number = ?");

--- a/src/main/java/com/frc/codex/model/SearchFilingsRequest.java
+++ b/src/main/java/com/frc/codex/model/SearchFilingsRequest.java
@@ -9,7 +9,6 @@ import org.thymeleaf.util.StringUtils;
 public class SearchFilingsRequest {
 	private Boolean admin;
 	private String searchText;
-	private long limit;
 	private Integer minDocumentDateDay;
 	private Integer minDocumentDateMonth;
 	private Integer minDocumentDateYear;
@@ -22,6 +21,8 @@ public class SearchFilingsRequest {
 	private Integer maxFilingDateDay;
 	private Integer maxFilingDateMonth;
 	private Integer maxFilingDateYear;
+	private int pageNumber;
+	private int pageSize;
 	private String registryCode;
 	private String status;
 
@@ -46,12 +47,12 @@ public class SearchFilingsRequest {
 	}
 
 	public long getLimit() {
-		return limit;
+		return pageSize;
 	}
 
-	public String getLoadMoreLink(long pageSize, int lastResultIndex) {
+	public String getLink(int pageNumber) {
 		String query = buildQuery("searchText", getSearchText()) +
-				buildQuery("limit", getLimit() + pageSize) +
+				buildQuery("pageNumber", pageNumber) +
 				buildQuery("minDocumentDateDay", getMinDocumentDateDay()) +
 				buildQuery("minDocumentDateMonth", getMinDocumentDateMonth()) +
 				buildQuery("minDocumentDateYear", getMinDocumentDateYear()) +
@@ -66,7 +67,11 @@ public class SearchFilingsRequest {
 				buildQuery("maxFilingDateYear", getMaxFilingDateYear()) +
 				buildQuery("registryCode", getRegistryCode()) +
 				buildQuery("admin", getAdmin());
-		return ("/?" + query + "#result-" + lastResultIndex);
+		return ("/?" + query);
+	}
+
+	public long getOffset() {
+		return (long) (pageNumber - 1) * pageSize;
 	}
 
 	private String buildQuery(String paramName, Object paramValue) {
@@ -143,6 +148,11 @@ public class SearchFilingsRequest {
 	public Integer getMaxFilingDateYear() {
 		return maxFilingDateYear;
 	}
+
+	public int getPageNumber() {
+		return pageNumber;
+	}
+
 	public String getRegistryCode() {
 		return registryCode;
 	}
@@ -163,9 +173,12 @@ public class SearchFilingsRequest {
 		this.searchText = searchText;
 	}
 
+	public void setPageNumber(int pageNumber) {
+		this.pageNumber = pageNumber;
+	}
 
-	public void setLimit(long limit) {
-		this.limit = limit;
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
 	}
 
 	public void setMinDocumentDateDay(Integer day) {

--- a/src/main/java/com/frc/codex/model/SearchFilingsResult.java
+++ b/src/main/java/com/frc/codex/model/SearchFilingsResult.java
@@ -1,0 +1,101 @@
+package com.frc.codex.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+public class SearchFilingsResult {
+	private final List<Filing> filings;
+	private final int lastPageNumber;
+	private final int maximumPageNumber;
+	private final int pageNumber;
+	private final int pageSize;
+	private final long totalFilings;
+
+	private SearchFilingsResult(Builder b) {
+		this.filings = b.filings;
+		this.maximumPageNumber = b.maximumPageNumber;
+		this.pageNumber = b.pageNumber;
+		this.pageSize = b.pageSize;
+		this.totalFilings = b.totalFilings;
+
+		this.lastPageNumber = (int) Math.min(maximumPageNumber, totalFilings / pageSize + 1);
+	}
+
+	public List<Filing> getFilings() {
+		return filings;
+	}
+
+	public int getLastPageNumber() {
+		return lastPageNumber;
+	}
+
+	public int getMaximumPageNumber() {
+		return maximumPageNumber;
+	}
+
+	public int getPageNumber() {
+		return pageNumber;
+	}
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public long getTotalFilings() {
+		return totalFilings;
+	}
+
+	public boolean isFirstPage() {
+		return getPageNumber() <= 1;
+	}
+
+	public boolean isLastPage() {
+		return getPageNumber() >= getLastPageNumber();
+	}
+
+	public boolean isMaximumResultsReturned() {
+		return totalFilings >= (long) maximumPageNumber * pageSize;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+		private List<Filing> filings;
+		private int maximumPageNumber;
+		private int pageNumber;
+		private int pageSize;
+		private long totalFilings;
+
+		public SearchFilingsResult build() {
+			return new SearchFilingsResult(this);
+		}
+
+		public SearchFilingsResult.Builder filings(List<Filing> filings) {
+			this.filings = filings;
+			return this;
+		}
+
+		public SearchFilingsResult.Builder maximumPageNumber(int maximumPageNumber) {
+			this.maximumPageNumber = maximumPageNumber;
+			return this;
+		}
+
+		public SearchFilingsResult.Builder pageNumber(int pageNumber) {
+			this.pageNumber = pageNumber;
+			return this;
+		}
+
+		public SearchFilingsResult.Builder pageSize(int pageSize) {
+			this.pageSize = pageSize;
+			return this;
+		}
+
+		public SearchFilingsResult.Builder totalFilings(long totalFilings) {
+			this.totalFilings = totalFilings;
+			return this;
+		}
+	}
+}

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -29,10 +29,10 @@ public interface FilingIndexProperties {
 	boolean isAws();
 	boolean isDbMigrateAsync();
 	int lambdaPreprocessingConcurrency();
-	long maximumSearchResults();
 	String s3IndexerUploadsBucketName();
 	String s3ResultsBucketName();
-	long searchPageSize();
+	int searchMaximumPages();
+	int searchPageSize();
 	String sqsJobsQueueName();
 	String sqsResultsQueueName();
 	String supportEmail();

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -44,9 +44,9 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String FILING_LIMIT_COMPANIES_HOUSE = "FILING_LIMIT_COMPANIES_HOUSE";
 	private static final String FILING_LIMIT_FCA = "FILING_LIMIT_FCA";
 	private static final String LAMBDA_PREPROCESSING_CONCURRENCY = "LAMBDA_PREPROCESSING_CONCURRENCY";
-	private static final String MAXIMUM_SEARCH_RESULTS = "MAXIMUM_SEARCH_RESULTS";
 	private static final String S3_INDEXER_UPLOADS_BUCKET_NAME = "S3_INDEXER_UPLOADS_BUCKET_NAME";
 	private static final String S3_RESULTS_BUCKET_NAME = "S3_RESULTS_BUCKET_NAME";
+	private static final String SEARCH_MAXIMUM_PAGES = "SEARCH_MAXIMUM_PAGES";
 	private static final String SEARCH_PAGE_SIZE = "SEARCH_PAGE_SIZE";
 	private static final String SECRETS_FILEPATH = "/run/secrets/frc-codex-server.secrets";
 	private static final String SQS_JOBS_QUEUE_NAME = "SQS_JOBS_QUEUE_NAME";
@@ -79,10 +79,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String awsLambdaFunctionName;
 	private final long awsLambdaTimeoutSeconds;
 	private final int lambdaPreprocessingConcurrency;
-	private final long maximumSearchResults;
 	private final String s3IndexerUploadsBucketName;
 	private final String s3ResultsBucketName;
-	private final long searchPageSize;
+	private final int searchMaximumPages;
+	private final int searchPageSize;
 	private final String sqsJobsQueueName;
 	private final String sqsResultsQueueName;
 	private final String supportEmail;
@@ -129,8 +129,8 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 		lambdaPreprocessingConcurrency = Integer.parseInt(requireNonNull(getEnv(LAMBDA_PREPROCESSING_CONCURRENCY, "1")));
 
-		maximumSearchResults = Long.parseLong(requireNonNull(getEnv(MAXIMUM_SEARCH_RESULTS, "100")));
-		searchPageSize = Long.parseLong(requireNonNull(getEnv(SEARCH_PAGE_SIZE, "10")));
+		searchMaximumPages = Integer.parseInt(requireNonNull(getEnv(SEARCH_MAXIMUM_PAGES, "10")));
+		searchPageSize = Integer.parseInt(requireNonNull(getEnv(SEARCH_PAGE_SIZE, "10")));
 
 		s3IndexerUploadsBucketName = requireNonNull(getEnv(S3_INDEXER_UPLOADS_BUCKET_NAME));
 		s3ResultsBucketName = requireNonNull(getEnv(S3_RESULTS_BUCKET_NAME));
@@ -310,10 +310,6 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		return lambdaPreprocessingConcurrency;
 	}
 
-	public long maximumSearchResults() {
-		return maximumSearchResults;
-	}
-
 	public String s3IndexerUploadsBucketName() {
 		return s3IndexerUploadsBucketName;
 	}
@@ -322,7 +318,11 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		return s3ResultsBucketName;
 	}
 
-	public long searchPageSize() {
+	public int searchMaximumPages() {
+		return searchMaximumPages;
+	}
+
+	public int searchPageSize() {
 		return searchPageSize;
 	}
 

--- a/src/main/resources/i18n/cy/index.json
+++ b/src/main/resources/i18n/cy/index.json
@@ -38,7 +38,10 @@
       "openViewer": "Gwyliwr Agored"
     },
     "header": "Canlyniadau",
-    "registry": "Cofrestrfa: "
+    "previous": "Blaenorol",
+    "next": "Nesaf",
+    "registry": "Cofrestrfa: ",
+    "totalFilingsMatched": "o ffeilio wedi cyfateb."
   },
   "searchButton": "Chwiliwch",
   "searchByNameOrNumber": "Chwilio yn ôl Enw neu Rif Cwmni",

--- a/src/main/resources/i18n/cy/index.json
+++ b/src/main/resources/i18n/cy/index.json
@@ -37,7 +37,7 @@
       "learnMore": "Dysgwch fwy.",
       "openViewer": "Gwyliwr Agored"
     },
-    "header": "Cofrestrfa",
+    "header": "Canlyniadau",
     "registry": "Cofrestrfa: "
   },
   "searchButton": "Chwiliwch",

--- a/src/main/resources/i18n/en/index.json
+++ b/src/main/resources/i18n/en/index.json
@@ -38,7 +38,10 @@
       "openViewer": "Open Viewer"
     },
     "header": "Results",
-    "registry": "Registry: "
+    "previous": "Previous",
+    "next": "Next",
+    "registry": "Registry: ",
+    "totalFilingsMatched": "total filings matched."
   },
   "searchButton": "Search",
   "searchByNameOrNumber": "Search by Company Name or Number",

--- a/src/main/resources/i18n/en/index.json
+++ b/src/main/resources/i18n/en/index.json
@@ -37,7 +37,7 @@
       "learnMore": "Learn more.",
       "openViewer": "Open Viewer"
     },
-    "header": "Registry",
+    "header": "Results",
     "registry": "Registry: "
   },
   "searchButton": "Search",

--- a/src/main/resources/i18n/es/index.json
+++ b/src/main/resources/i18n/es/index.json
@@ -37,7 +37,7 @@
       "learnMore": "Más información.",
       "openViewer": "Visor Abierto"
     },
-    "header": "Registro",
+    "header": "Resultados",
     "registry": "Registro: "
   },
   "searchButton": "Buscar",

--- a/src/main/resources/i18n/es/index.json
+++ b/src/main/resources/i18n/es/index.json
@@ -38,7 +38,10 @@
       "openViewer": "Visor Abierto"
     },
     "header": "Resultados",
-    "registry": "Registro: "
+    "previous": "Previo",
+    "next": "Próximo",
+    "registry": "Registro: ",
+    "totalFilingsMatched": "presentaciones totales coincidentes."
   },
   "searchButton": "Buscar",
   "searchByNameOrNumber": "Búsqueda por Nombre o Número de Empresa",

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -156,9 +156,51 @@
         <p th:if="${message != null}" class="govuk-body">
             <i th:text="${message}"></i>
         </p>
-        <div th:if="${filings != null && filings.size() > 0}" class="search-result">
+        <div th:if="${searchFilingsResult.getFilings() != null && searchFilingsResult.getFilings().size() > 0}" class="search-result">
             <h3 class="govuk-heading-m" data-i18n="index:results.header">Results</h3>
-            <div th:each="filing, iter : ${filings}" th:id="|result-${iter.index}|">
+            <h5 class="govuk-heading-s"> <span th:text="${filingsCount}"></span> total filings matched.</h5>
+            <div style="display: flex;justify-content: center;">
+                <nav class="govuk-pagination" aria-label="Pagination">
+                    <div th:if="${!searchFilingsResult.isFirstPage()}" class="govuk-pagination__prev">
+                        <a class="govuk-link govuk-pagination__link"
+                           th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() - 1)}"
+                           rel="prev">
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                            </svg>
+                            <span class="govuk-pagination__link-title">
+                                Previous<span class="govuk-visually-hidden"> page</span>
+                            </span>
+                        </a>
+                    </div>
+                    <ul class="govuk-pagination__list">
+                        <li th:each="pageLink, iter : ${pageLinks}"
+                            class="govuk-pagination__item"
+                            th:classappend="${pageLink.getValue()}">
+                            <a class="govuk-link govuk-pagination__link"
+                                th:if="${pageLink.getKey() != null}"
+                                th:text="${pageLink.getKey()} ?: '&ctdot;'"
+                                th:href="${searchFilingsRequest.getLink(pageLink.getKey())}">
+                                &ctdot;
+                            </a>
+                            <span th:if="${pageLink.getKey() == null}">&ctdot;</span>
+                        </li>
+                    </ul>
+                    <div th:if="${!searchFilingsResult.isLastPage()}" class="govuk-pagination__next">
+                        <a class="govuk-link govuk-pagination__link"
+                           th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() + 1)}"
+                           rel="next">
+                            <span class="govuk-pagination__link-title">
+                                Next<span class="govuk-visually-hidden"> page</span>
+                            </span>
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                                <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </nav>
+            </div>
+            <div th:each="filing, iter : ${searchFilingsResult.getFilings()}" th:id="|result-${iter.index}|">
                 <hr/>
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
@@ -239,12 +281,50 @@
                     </div>
                 </div>
             </div>
-            <p th:if="${moreResultsLink != null}" class="govuk-body" style="text-align: center; padding:1em;">
-                <a th:href="${moreResultsLink}" data-i18n="index:loadMore">Load more filings</a>
-            </p>
-            <p th:if="${maximumResultsReturned}" class="govuk-body" style="text-align: center" data-i18n="index:maxResults">
+            <p th:if="${searchFilingsResult.isLastPage() && searchFilingsResult.isMaximumResultsReturned()}" class="govuk-body" style="text-align: center;padding:2em;" data-i18n="index:maxResults">
                 Maximum number of results returned. Please refine your search.
             </p>
+            <div style="display: flex;justify-content: center;">
+                <nav class="govuk-pagination" aria-label="Pagination">
+                    <div th:if="${!searchFilingsResult.isFirstPage()}" class="govuk-pagination__prev">
+                        <a class="govuk-link govuk-pagination__link"
+                           th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() - 1)}"
+                           rel="prev">
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                            </svg>
+                            <span class="govuk-pagination__link-title">
+                                Previous<span class="govuk-visually-hidden"> page</span>
+                            </span>
+                        </a>
+                    </div>
+                    <ul class="govuk-pagination__list">
+                        <li th:each="pageLink, iter : ${pageLinks}"
+                            class="govuk-pagination__item"
+                            th:classappend="${pageLink.getValue()}">
+                            <a class="govuk-link govuk-pagination__link"
+                               th:if="${pageLink.getKey() != null}"
+                               th:text="${pageLink.getKey()} ?: '&ctdot;'"
+                               th:href="${searchFilingsRequest.getLink(pageLink.getKey())}">
+                                &ctdot;
+                            </a>
+                            <span th:if="${pageLink.getKey() == null}">&ctdot;</span>
+                        </li>
+                    </ul>
+                    <div th:if="${!searchFilingsResult.isLastPage()}" class="govuk-pagination__next">
+                        <a class="govuk-link govuk-pagination__link"
+                           th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() + 1)}"
+                           rel="next">
+                            <span class="govuk-pagination__link-title">
+                                Next<span class="govuk-visually-hidden"> page</span>
+                            </span>
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                                <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </nav>
+            </div>
         </div>
     </main>
 </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -158,7 +158,7 @@
         </p>
         <div th:if="${searchFilingsResult.getFilings() != null && searchFilingsResult.getFilings().size() > 0}" class="search-result">
             <h3 class="govuk-heading-m" data-i18n="index:results.header">Results</h3>
-            <h5 class="govuk-heading-s"> <span th:text="${filingsCount}"></span> total filings matched.</h5>
+            <h5 class="govuk-heading-s"> <span th:text="${filingsCount}"></span> <span data-i18n="index:results.totalFilingsMatched">total filings matched.</span></h5>
             <div style="display: flex;justify-content: center;">
                 <nav class="govuk-pagination" aria-label="Pagination">
                     <div th:if="${!searchFilingsResult.isFirstPage()}" class="govuk-pagination__prev">
@@ -168,8 +168,8 @@
                             <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
                             </svg>
-                            <span class="govuk-pagination__link-title">
-                                Previous<span class="govuk-visually-hidden"> page</span>
+                            <span class="govuk-pagination__link-title" data-i18n="index:results.previous">
+                                Previous
                             </span>
                         </a>
                     </div>
@@ -190,8 +190,8 @@
                         <a class="govuk-link govuk-pagination__link"
                            th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() + 1)}"
                            rel="next">
-                            <span class="govuk-pagination__link-title">
-                                Next<span class="govuk-visually-hidden"> page</span>
+                            <span class="govuk-pagination__link-title" data-i18n="index:results.next">
+                                Next
                             </span>
                             <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                                 <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
@@ -293,8 +293,8 @@
                             <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
                             </svg>
-                            <span class="govuk-pagination__link-title">
-                                Previous<span class="govuk-visually-hidden"> page</span>
+                            <span class="govuk-pagination__link-title" data-i18n="index:results.previous">
+                                Previous
                             </span>
                         </a>
                     </div>
@@ -315,8 +315,8 @@
                         <a class="govuk-link govuk-pagination__link"
                            th:href="${searchFilingsRequest.getLink(searchFilingsResult.getPageNumber() + 1)}"
                            rel="next">
-                            <span class="govuk-pagination__link-title">
-                                Next<span class="govuk-visually-hidden"> page</span>
+                            <span class="govuk-pagination__link-title" data-i18n="index:results.next">
+                                Next
                             </span>
                             <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
                                 <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -82,6 +82,10 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 		return List.of();
 	}
 
+	public long getFilingsCount(SearchFilingsRequest searchFilingsRequest) {
+		return 0;
+	}
+
 	public long getRegistryCount(RegistryCode registryCode) {
 		return 0;
 	}

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -122,10 +122,6 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return 1;
 	}
 
-	public long maximumSearchResults() {
-		return 100;
-	}
-
 	public String s3ResultsBucketName() {
 		return "frc-codex-results";
 	}
@@ -134,7 +130,11 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return "frc-codex-indexer-uploads";
 	}
 
-	public long searchPageSize() {
+	public int searchMaximumPages() {
+		return 10;
+	}
+
+	public int searchPageSize() {
 		return 10;
 	}
 


### PR DESCRIPTION
#### Reason for change
"Load more filings" UX was not ideal.

#### Description of change
Load up to 10 pages of 10 (100 maximum results) as well as show the total number of filings matched.

#### Steps to Test
CI

![Screenshot 2025-02-26 at 11 11 24 AM](https://github.com/user-attachments/assets/d7e6a859-2255-4cc2-8556-73dcfaacd5f2)
![Screenshot 2025-02-26 at 11 10 58 AM](https://github.com/user-attachments/assets/59211112-6e65-4417-8e57-206d81f5b78f)
![Screenshot 2025-02-26 at 11 10 53 AM](https://github.com/user-attachments/assets/bcf1bf12-2855-43a0-9e13-445471fee3e8)
![Screenshot 2025-02-26 at 11 10 45 AM](https://github.com/user-attachments/assets/2e25d1cf-7bc2-44c8-9246-6b4fefbd85b7)
![Screenshot 2025-02-26 at 11 10 40 AM](https://github.com/user-attachments/assets/09ff0b5c-1713-4ef0-8210-8b9497cd36dd)
![Screenshot 2025-02-26 at 11 13 29 AM](https://github.com/user-attachments/assets/a13e56b6-fd93-4ab3-a937-c7246f74c49e)


**review**:
@Arelle/arelle
