### PR TITLE
Support parsing "delete" stream events, handle parsing failures

### DIFF
--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
@@ -256,25 +256,32 @@ public class CompaniesHouseClientImpl implements CompaniesHouseClient {
 
 	public CompaniesHouseFiling parseStreamedFiling(String json) throws JsonProcessingException {
 		JsonNode filing = OBJECT_MAPPER.readTree(json);
-		JsonNode data = filing.get("data");
+
 		JsonNode event = filing.get("event");
+		String eventType = event.get("type").asText();
+		long timepoint = event.get("timepoint").asLong();
+
+		String resourceId = filing.get("resource_id").asText();
+		String resourceKind = filing.get("resource_kind").asText();
 		String resourceUri = filing.get("resource_uri").asText();
 		String[] resourceUriSplit = resourceUri.split("/");
-
-		// Note: `action_date` is not a documented field but appears to consistently represent
-		// the document date for the filing.
-		LocalDateTime actionDate = parseDate(data.get("action_date"));
-		String category = null;
-		if (data.has("category")) {
-			category = data.get("category").asText();
-		}
 		String companyNumber = resourceUriSplit[2];
-		LocalDateTime date = parseDate(data.get("date"));
-		String eventType = event.get("type").asText();
-		String resourceKind = filing.get("resource_kind").asText();
-		String resourceId = filing.get("resource_id").asText();
-		long timepoint = event.get("timepoint").asLong();
-		String transactionId = data.get("transaction_id").asText();
+
+		LocalDateTime actionDate = null;
+		String category = null;
+		LocalDateTime date = null;
+		String transactionId = null;
+		if (filing.has("data")) {
+			JsonNode data = filing.get("data");
+			// Note: `action_date` is not a documented field but appears to consistently represent
+			// the document date for the filing.
+			actionDate = parseDate(data.get("action_date"));
+			if (data.has("category")) {
+				category = data.get("category").asText();
+			}
+			date = parseDate(data.get("date"));
+			transactionId = data.get("transaction_id").asText();
+		}
 		return new CompaniesHouseFiling(
 				actionDate,
 				category,

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -148,7 +148,7 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 				// progress will slow as each batch fills in with events that can't be parsed.
 				// If this ends up being problematic, we can make a change here to delete
 				// these stream events.
-				LOG.error("Failed to parse CH filing stream event.", e);
+				LOG.error("Failed to parse CH filing stream event: {}", streamEvent.getStreamEventId(), e);
 				continue;
 			}
 

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -141,9 +141,15 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 			CompaniesHouseFiling companiesHouseFiling;
 			try {
 				companiesHouseFiling = companiesHouseClient.parseStreamedFiling(streamEvent.getJson());
-			} catch (JsonProcessingException e) {
+			} catch (Exception e) {
+				// Parsing failed, skip this event.
+				// Note that this event will attempt processing again in the next batch, so
+				// the underlying issue should be addressed promptly, otherwise indexing
+				// progress will slow as each batch fills in with events that can't be parsed.
+				// If this ends up being problematic, we can make a change here to delete
+				// these stream events.
 				LOG.error("Failed to parse CH filing stream event.", e);
-				break;
+				continue;
 			}
 
 			long timepoint;


### PR DESCRIPTION
#### Reason for change
Stream indexing breaks entirely when it encounters a stream event it can't parse. Specifically, "deleted" stream events that don't have a "data" element.

#### Description of change
Correctly parse "deleted" events.
Fail more gracefully when parsing stream events fails. This solution allows the stream indexer to continue, but it will re-attempt parsing failed events on subsequent batches. We'll need to address them (by fixing parsing, or manually deleting the event in the DB) promptly or else each batch will fill with unparseable events.

#### Steps to Test
Insert stream event with invalid JSON and timepoint = 0
Insert "deleted" stream event with timepoint = 0
Example JSON: 
```
{"resource_kind":"filing-history","resource_uri":"/company/09674538/filing-history/MzQ0MzA1ODg2OWFkaXF6a2N4","resource_id":"MzQ0MzA1ODg2OWFkaXF6a2N4","event":{"timepoint":185461933,"published_at":"2025-02-25T14:41:05","type":"deleted"}}
```

The invalid JSON stream event should trigger an ERROR log initially and on subsequent batches.
The "deleted" stream event should be processed silently.

**review**:
@Arelle/arelle
