### PR TITLE
Improve rapid rate limiter

### DIFF
--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -19,7 +19,7 @@ echo "Test homepage"
 curl $CURL_OPTS http://localhost:8080/
 
 echo "Test CH API client"
-curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/company/00324341
+curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/company/10178367
 
 echo "Test CH archive client"
 curl $CURL_OPTS http://localhost:8080/admin/smoketest/companieshouse/history

--- a/src/main/java/com/frc/codex/controllers/AdminController.java
+++ b/src/main/java/com/frc/codex/controllers/AdminController.java
@@ -138,7 +138,7 @@ public class AdminController extends BaseController {
 		String filingUrls = filings.stream()
 				.map(NewFilingRequest::getDownloadUrl)
 				.collect(Collectors.joining("\n"));
-		model.addAttribute("filings", filingUrls);
+		model.addAttribute("filingUrls", filingUrls);
 		return "admin/smoketest/companieshouse/company";
 	}
 

--- a/src/main/java/com/frc/codex/tools/RateLimiter.java
+++ b/src/main/java/com/frc/codex/tools/RateLimiter.java
@@ -1,6 +1,5 @@
 package com.frc.codex.tools;
 
-import java.sql.Timestamp;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -10,39 +9,43 @@ import org.slf4j.LoggerFactory;
 public class RateLimiter
 {
 	private static final Logger LOG = LoggerFactory.getLogger(RateLimiter.class);
-	protected final Queue<Timestamp> timestamps;
+	private static final int MONITOR_FACTOR = 100;
+	protected final Queue<Long> monitorTimestamps;
 	protected final int rapidRateLimit;
 	protected final int rapidRateWindow;
+	private long waitUntilMs;
 
 	public RateLimiter(int rapidRateLimit, int rapidRateWindow) {
 		this.rapidRateLimit = rapidRateLimit;
 		this.rapidRateWindow = rapidRateWindow;
-		this.timestamps = new ConcurrentLinkedQueue<>();
+		this.monitorTimestamps = new ConcurrentLinkedQueue<>();
+		waitUntilMs = System.currentTimeMillis();
 	}
 
-	public void registerTimestamp() {
-		Timestamp now = new Timestamp(System.currentTimeMillis());
-		timestamps.add(now);
+	public synchronized void registerTimestamp() {
+		monitorTimestamps.add(System.currentTimeMillis());
 
 		// Remove timestamps older than one minute
-		Timestamp oneMinuteAgo = new Timestamp(now.getTime() - rapidRateWindow);
-		while (!timestamps.isEmpty() && timestamps.peek().before(oneMinuteAgo)) {
-			timestamps.poll();
+		long threshold = System.currentTimeMillis() - (long) rapidRateWindow * MONITOR_FACTOR;
+		while (!monitorTimestamps.isEmpty() && monitorTimestamps.peek() < threshold) {
+			monitorTimestamps.poll();
 		}
+		waitUntilMs = System.currentTimeMillis() + rapidRateWindow;
+	}
+
+	public double getRequestsPerSecond() {
+		Long oldest = monitorTimestamps.peek();
+		if (oldest == null) {
+			return 0.0;
+		}
+		return (double) monitorTimestamps.size() / (System.currentTimeMillis() - oldest) * 1000.0;
 	}
 
 	public synchronized void waitForRapidRateLimit() throws InterruptedException {
-		Timestamp now = new Timestamp(System.currentTimeMillis());
-		if (timestamps.size() >= rapidRateLimit) {
-			Timestamp oldest = timestamps.peek();
-			if (oldest == null) {
-				return;
-			}
-			long waitTime = rapidRateWindow - (now.getTime() - oldest.getTime());
-			if (waitTime > 0) {
-				LOG.info("Waiting for rapid rate limit: {} ms", waitTime);
-				Thread.sleep(waitTime);
-			}
+		long waitTime = waitUntilMs - System.currentTimeMillis();
+		if (waitTime > 0) {
+			LOG.info("Waiting for rapid rate limit: {} ms (requestsPerSecond={})", waitTime, String.format("%.2f", getRequestsPerSecond()));
+			Thread.sleep(waitTime);
 		}
 	}
 }


### PR DESCRIPTION
#### Reason for change
The rapid rate limiter fails to prevent 429 responses, specifically when multiple indexer jobs are pinging the CH API.

#### Description of change
A couple of issues contributed to this:
- Each API caller checked the status of the rate limiter, waiting as necessary, before making an API call, then registered the call with the limiter afterwards. This meant that multiple callers might be held up during the health-check/wait before all being released simultaneously to make a burst of API calls, putting the limiter into an unhealthy state, but the damage from the burst of requests may have already triggered a 429 response.
- The timestamp-based approach was more designed around limiting a number of requests over a certain period of time such as 10-20 seconds. Since we've moved towards a much more granular approach (only allowing 1 request within X seconds), the timestamp tracking was both needlessly complicated and not very effective.

This PR implements a more granular and simpler rate limit approach: always wait X milliseconds after any request before making another. Local testing has confirmed that this simpler approach works near perfectly.

#### Steps to Test
Set up your environment to ensure both stream and company indexing are running concurrently, and verify no 429 requests occur with `COMPANIES_HOUSE_RAPID_RATE_WINDOW=500`. The `requestsPerSecond` logs should also reflect numbers close to the expected rate of 2/sec.

**review**:
@Arelle/arelle
