### PR TITLE
Cleanup smoketest

### DIFF
--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -46,7 +46,7 @@ curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
 
 echo "Test support action: get_filing_details"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
-  --data '{"action":"get_filing_details","filing_id":"abcdefg"}'
+  --data '{"action":"get_filing_details","filing_id":"cfc59bc3-1899-40ae-87f3-bd199bee8171"}'
 
 echo "Test support action: list_errors"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \

--- a/support/actions/get_filing_details_action.py
+++ b/support/actions/get_filing_details_action.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from support.actions.base_action import BaseAction
@@ -9,6 +10,10 @@ class GetFilingDetailsAction(BaseAction):
         if 'filing_id' not in options:
             return False, "Must provide 'filing_id'.", 0
         filing_id = options['filing_id']
+        try:
+            uuid.UUID(filing_id)
+        except ValueError:
+            return False, f"filing_id must be a valid UUID: {filing_id}", 0
         query = "SELECT * FROM filings WHERE filing_id = %s LIMIT 1;"
         cursor.execute(query, (filing_id,))
         results = BaseAction.collect_results(cursor)

--- a/support/actions/reset_archives_action.py
+++ b/support/actions/reset_archives_action.py
@@ -14,19 +14,19 @@ class ResetArchivesAction(BaseAction):
             return False, "Must provide at least one of 'archive_type', " \
                           "'filename', 'completed_after', or " \
                           "'completed_before'.", 0
-        if options.get('archive_type'):
+        if options.get('archive_type') is not None:
             conditions.append("archive_type = %s")
             params.append(options['archive_type'])
             notes.append(f"Archive type is {options['archive_type']}.")
-        if options.get('filename'):
+        if options.get('filename') is not None:
             conditions.append("filename LIKE %s")
             params.append(options['filename'])
             notes.append(f"Filename matches {options['filename']}.")
-        if options.get('completed_after'):
+        if options.get('completed_after') is not None:
             conditions.append("completed_date >= %s")
             params.append(options['completed_after'])
             notes.append(f"Completion date is after {options['completed_after']}.")
-        if options.get('completed_before'):
+        if options.get('completed_before') is not None:
             conditions.append("completed_date < %s")
             params.append(options['completed_before'])
             notes.append(f"Completion date is before {options['completed_before']}.")

--- a/support/actions/reset_companies_action.py
+++ b/support/actions/reset_companies_action.py
@@ -23,23 +23,23 @@ class ResetCompaniesAction(BaseAction):
             return False, "Must provide at least one of 'company_number', " \
                           "'completed_after', 'completed_before', 'discovered_after', " \
                           "or 'discovered_before'.", 0
-        if options.get('company_number'):
+        if options.get('company_number') is not None:
             conditions.append("company_number = %s")
             params.append(options['company_number'])
             notes.append(f"Company number is {options['company_number']}.")
-        if options.get('completed_after'):
+        if options.get('completed_after') is not None:
             conditions.append("completed_date >= %s")
             params.append(options['completed_after'])
             notes.append(f"Completion date is after {options['completed_after']}.")
-        if options.get('completed_before'):
+        if options.get('completed_before') is not None:
             conditions.append("completed_date < %s")
             params.append(options['completed_before'])
             notes.append(f"Completion date is before {options['completed_before']}.")
-        if options.get('discovered_after'):
+        if options.get('discovered_after') is not None:
             conditions.append("discovered_date >= %s")
             params.append(options['discovered_after'])
             notes.append(f"Discovery date is after {options['discovered_after']}.")
-        if options.get('discovered_before'):
+        if options.get('discovered_before') is not None:
             conditions.append("discovered_date < %s")
             params.append(options['discovered_before'])
             notes.append(f"Discovery date is before {options['discovered_before']}.")

--- a/support/actions/reset_filings_action.py
+++ b/support/actions/reset_filings_action.py
@@ -11,19 +11,20 @@ class ResetFilingsAction(BaseAction):
         notes = []
         if 'company_number' not in options and 'filing_id' not in options:
             return False, "Must provide 'company_number', 'filing_id', or both.", 0
-        if options.get('company_number'):
+        if options.get('company_number') is not None:
             conditions.append("company_number = %s")
             params.append(options['company_number'])
             notes.append(f"Company number is {options['company_number']}.")
         if options.get('filing_id') is not None:
+            filing_id = options['filing_id']
             try:
-                uuid.UUID(options['filing_id'])
+                uuid.UUID(filing_id)
             except ValueError:
-                return False, f"filing_id must be a valid UUID: {options['filing_id']}", 0
+                return False, f"filing_id must be a valid UUID: {filing_id}", 0
             conditions.append("filing_id = %s")
-            params.append(options['filing_id'])
+            params.append(filing_id)
             notes.append(f"Filing ID is {options['filing_id']}.")
-        if options.get('status'):
+        if options.get('status') is not None:
             conditions.append("status = %s")
             params.append(options['status'])
             notes.append(f"Status is {options['status']}.")

--- a/support/actions/reset_filings_action.py
+++ b/support/actions/reset_filings_action.py
@@ -1,3 +1,5 @@
+import uuid
+
 from support.actions.base_action import BaseAction
 
 
@@ -13,7 +15,11 @@ class ResetFilingsAction(BaseAction):
             conditions.append("company_number = %s")
             params.append(options['company_number'])
             notes.append(f"Company number is {options['company_number']}.")
-        if options.get('filing_id'):
+        if options.get('filing_id') is not None:
+            try:
+                uuid.UUID(options['filing_id'])
+            except ValueError:
+                return False, f"filing_id must be a valid UUID: {options['filing_id']}", 0
             conditions.append("filing_id = %s")
             params.append(options['filing_id'])
             notes.append(f"Filing ID is {options['filing_id']}.")

--- a/support/actions/reset_stream_events_action.py
+++ b/support/actions/reset_stream_events_action.py
@@ -14,19 +14,19 @@ class ResetStreamEventsAction(BaseAction):
             return False, "Must provide at least one of 'created_after', " \
                           "'created_before', 'timepoint_after', or " \
                           "'timepoint_before'.", 0
-        if options.get('created_after'):
+        if options.get('created_after') is not None:
             conditions.append("created_date >= %s")
             params.append(options['created_after'])
             notes.append(f"Creation date is after {options['created_after']}.")
-        if options.get('created_before'):
+        if options.get('created_before') is not None:
             conditions.append("created_date < %s")
             params.append(options['created_before'])
             notes.append(f"Creation date is before {options['created_before']}.")
-        if options.get('timepoint_after'):
+        if options.get('timepoint_after') is not None:
             conditions.append("timepoint >= %s")
             params.append(options['timepoint_after'])
             notes.append(f"Timepoint is after {options['timepoint_after']}.")
-        if options.get('timepoint_before'):
+        if options.get('timepoint_before') is not None:
             conditions.append("timepoint < %s")
             params.append(options['timepoint_before'])
             notes.append(f"Timepoint is before {options['timepoint_before']}.")


### PR DESCRIPTION
#### Reason for change
A couple of errors were being thrown in the smoke test for support actions. Actions checked that options were not None to begin, but only included the values if they were truthy (which the smoke test value of `0` for `timepoint_before` created an empty where clause). Also querying with an invalid UUID for a filing_id threw an error.

#### Description of change
* Check UUIDs in support actions.
* Include 0 value options from support actions.

#### Steps to Test
* CI/smoke test

**review**:
@Arelle/arelle
