### PR TITLE
Remove markdown from translations text

### DIFF
--- a/src/main/resources/i18n/cy/help.json
+++ b/src/main/resources/i18n/cy/help.json
@@ -1,6 +1,7 @@
 {
   "contactUs": "Cysylltwch â Ni",
-  "emailInstructions": "Defnyddiwch y cyfeiriad e-bost hwn i gysylltu â'n staff gydag unrhyw gwestiynau, problemau neu adborth sydd gennych am y Gwyliwr iXBRL y DU.<br> Gall rhai manylion defnyddiol gynnwys enw'r cwmni, rhif cwmni, neu URL sy'n gysylltiedig â gwyliwr neu ffeil benodol.",
+  "emailInstructionsDetails": "Gall rhai manylion defnyddiol gynnwys enw'r cwmni, rhif cwmni, neu URL sy'n gysylltiedig â gwyliwr neu ffeil benodol.",
+  "emailInstructionsFeedback": "Defnyddiwch y cyfeiriad e-bost hwn i gysylltu â'n staff gydag unrhyw gwestiynau, problemau neu adborth sydd gennych am y Gwyliwr iXBRL y DU.",
   "noEmail": "Gwasanaeth wedi'i ddefnyddio heb gyfeiriad e-bost cymorth (newidyn amgylchedd: SUPPORT_EMAIL).",
   "respond": "Bydd aelod o’n staff yn ymateb i’ch cais cyn gynted â phosibl.",
   "respondId": "Cais ID",

--- a/src/main/resources/i18n/cy/index.json
+++ b/src/main/resources/i18n/cy/index.json
@@ -9,7 +9,6 @@
     "to": "I",
     "year": "Blwyddyn"
   },
-  "loadMore": "Llwytho mwy o ffeilio",
   "maxResults": "Uchafswm nifer y canlyniadau a ddychwelwyd. Mireiniwch eich chwiliad.",
   "nationalStorageMechanism": "Mecanwaith Cynhesu Cenedlaethol",
   "registry": {
@@ -40,8 +39,8 @@
       "openViewer": "Gwyliwr Agored"
     },
     "header": "Canlyniadau",
-    "previous": "Blaenorol",
     "next": "Nesaf",
+    "previous": "Blaenorol",
     "registry": "Cofrestrfa: ",
     "totalFilingsMatched": "o ffeilio wedi cyfateb."
   },

--- a/src/main/resources/i18n/en/help.json
+++ b/src/main/resources/i18n/en/help.json
@@ -1,6 +1,7 @@
 {
   "contactUs": "Contact Us",
-  "emailInstructions": "Use this email address to contact our staff with any questions, issues, or feedback you have about the UK iXBRL Viewer.<br> Some helpful details may include the company name, company number, or URL associated with a specific viewer or filing.",
+  "emailInstructionsDetails": "Some helpful details may include the company name, company number, or URL associated with a specific viewer or filing.",
+  "emailInstructionsFeedback": "Use this email address to contact our staff with any questions, issues, or feedback you have about the UK iXBRL Viewer.",
   "noEmail": "Service deployed without support email address (environment variable: SUPPORT_EMAIL).",
   "respond": "A member of our staff will respond to your request as soon as possible.",
   "respondId": "Request ID",

--- a/src/main/resources/i18n/en/index.json
+++ b/src/main/resources/i18n/en/index.json
@@ -9,7 +9,6 @@
     "to": "To",
     "year": "Year"
   },
-  "loadMore": "Load more filings",
   "maxResults": "Maximum number of results returned. Please refine your search.",
   "nationalStorageMechanism": "National Storage Mechanism",
   "registry": {
@@ -40,8 +39,8 @@
       "openViewer": "Open Viewer"
     },
     "header": "Results",
-    "previous": "Previous",
     "next": "Next",
+    "previous": "Previous",
     "registry": "Registry: ",
     "totalFilingsMatched": "total filings matched."
   },

--- a/src/main/resources/i18n/es/help.json
+++ b/src/main/resources/i18n/es/help.json
@@ -1,6 +1,7 @@
 {
   "contactUs": "Contacta con nosotros",
-  "emailInstructions": "Utilice esta dirección de correo electrónico para ponerse en contacto con nuestro personal si tiene alguna pregunta, problema o comentario sobre el visor iXBRL del Reino Unido.<br>Algunos detalles útiles pueden incluir el nombre de la empresa, el número de la empresa o la URL asociada con un visor o archivo específico.",
+  "emailInstructionsDetails": "Algunos detalles útiles pueden incluir el nombre de la empresa, el número de la empresa o la URL asociada con un visor o archivo específico.",
+  "emailInstructionsFeedback": "Utilice esta dirección de correo electrónico para ponerse en contacto con nuestro personal si tiene alguna pregunta, problema o comentario sobre el visor iXBRL del Reino Unido.",
   "noEmail": "Servicio implementado sin dirección de correo electrónico de soporte (variable de entorno: SUPPORT_EMAIL).",
   "respond": "Un miembro de nuestro personal responderá a su solicitud lo antes posible.",
   "respondId": "Solicitar ID",

--- a/src/main/resources/i18n/es/index.json
+++ b/src/main/resources/i18n/es/index.json
@@ -9,7 +9,6 @@
     "to": "A",
     "year": "Año"
   },
-  "loadMore": "Cargar más presentaciones",
   "maxResults": "Número máximo de resultados devueltos. Por favor, refine su búsqueda.",
   "nationalStorageMechanism": "Mecanismo de Almacenamiento Nacional",
   "registry": {
@@ -40,8 +39,8 @@
       "openViewer": "Visor Abierto"
     },
     "header": "Resultados",
-    "previous": "Previo",
     "next": "Próximo",
+    "previous": "Previo",
     "registry": "Registro: ",
     "totalFilingsMatched": "presentaciones totales coincidentes."
   },

--- a/src/main/resources/templates/help.html
+++ b/src/main/resources/templates/help.html
@@ -39,11 +39,11 @@
                 </div>
             </div>
         </div>
-        <p class="govuk-body" data-i18n="help:emailInstructions">
-            Use this email address to contact our staff with any questions, issues,
-            or feedback you have about the UK iXBRL Viewer.<br>
-            Some helpful details may include the company name, company number,
-            or URL associated with a specific viewer or filing.
+        <p class="govuk-body">
+            <span data-i18n="help:emailInstructionsFeedback">Use this email address to contact our staff with any questions, issues,
+            or feedback you have about the UK iXBRL Viewer.</span><br>
+            <span data-i18n="help:emailInstructionsDetails">Some helpful details may include the company name, company number,
+            or URL associated with a specific viewer or filing.</span>
         </p>
         <p class="govuk-body">
             <span th:if="${supportEmail == null}" data-i18n="help:noEmail">Service deployed without support email address (environment variable: SUPPORT_EMAIL).</span>


### PR DESCRIPTION
#### Reason for change
`<br>` markup was included in translated text. 

#### Description of change
Split line break text into two sections.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
