### PR TITLE
Adding tooltip to date_filed field.

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -67,33 +67,6 @@ html, body {
     padding: 6px 0;
 }
 
-.search-result .index-link {
-    position: relative;
-    white-space: nowrap;
-}
-
-.search-result .index-link .index-tooltip {
-    display: none;
-    white-space: normal;
-    position: absolute;
-    right: 0;
-    top: 100%;
-    width: 200px;
-    background: white;
-    border: 1px solid black;
-    padding: 10px;
-    z-index: 1;
-    box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.1);
-}
-
-.search-result .index-link:hover .index-tooltip {
-    display: block;
-}
-
-.search-result .index-link img {
-    margin-bottom: -3px;
-}
-
 .search-result hr {
     margin: 20px 0;
 }
@@ -159,6 +132,39 @@ header a:hover {
     height: unset;
     height: 2rem;
     font-size: 14px;
+}
+
+.index-link {
+    position: relative;
+    white-space: nowrap;
+}
+
+.index-link .index-tooltip {
+    display: none;
+    white-space: normal;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    width: 200px;
+    background: white;
+    border: 1px solid black;
+    padding: 10px;
+    z-index: 1;
+    box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.1);
+}
+
+
+.index-link .index-tooltip.index-tooltip-left {
+    right: auto;
+    left: 0;
+}
+
+.index-link:hover .index-tooltip {
+    display: block;
+}
+
+.index-link img {
+    margin-bottom: -3px;
 }
 
 .govuk-header__container {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -42,8 +42,13 @@
                     <div class="govuk-form-group" th:classappend="${minFilingDateError != null} ? govuk-form-group--error : govuk-form-group--valid">
                         <fieldset class="govuk-fieldset" role="group" aria-describedby="min-filing-date-hint">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                                <h1 class="govuk-fieldset__legend" data-i18n="index:dateFiled.header">
-                                    Date Filed
+                                <h1 class="govuk-fieldset__legend"> <span data-i18n="index:dateFiled.header"> Date Filed </span>
+                                    <span class="index-link">
+                                            <img src="/icons/info.svg" alt="Info icon" height="16" width="16">
+                                            <span class="index-tooltip index-tooltip-left">
+                                                <span class="original-text" data-i18n="index:results.dateFiledTooltip">The date on which the report was filed with Companies House Registry or FCA.</span>
+                                            </span>
+                                    </span>
                                 </h1>
                             </legend>
                             <div id="min-filing-date-hint" class="govuk-hint" data-i18n="index:dateFiled.from">


### PR DESCRIPTION
#### Description of change

Added tooltip to Date Filed field.
Moved the tooltip out from under search results for greater usability.

#### Steps to Test

CI

![dated_filed_tooltips](https://github.com/user-attachments/assets/1fa4e77e-04df-4866-ab5e-7e3bdf00bbb7)



**review**:
@Arelle/arelle
