### PR TITLE
Optimize company reset search

### DIFF
--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -1,5 +1,6 @@
 package com.frc.codex.database;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -27,6 +28,7 @@ public interface DatabaseManager {
 	void deleteStreamEvent(UUID streamEventId);
 	boolean filingExists(String registryCode, String externalFilingId);
 	Filing getFiling(UUID filingId);
+	Filing getFiling(String companyNumber, LocalDate documentDate);
 	List<Filing> getFilingsByStatus(FilingStatus status);
 	List<Filing> getFilingsByStatus(FilingStatus status, RegistryCode registryCode);
 	long getFilingsCount(SearchFilingsRequest searchFilingsRequest);

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -1,5 +1,6 @@
 package com.frc.codex.database.impl;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -63,6 +64,10 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 	}
 
 	public Filing getFiling(UUID filingId) {
+		return null;
+	}
+
+	public Filing getFiling(String companyNumber, LocalDate documentDate) {
 		return null;
 	}
 


### PR DESCRIPTION
#### Reason for change
The method for looking up if an archive entry had a matching filing already indexed was not efficient.

#### Description of change
Search for a matching filing more directly with a dedicated query.

#### Steps to Test
Trigger a "daily" archive to be downloaded that contains an arcname that matches a filing that's already been indexed. Confirm that the associated company number is not "reset" for company indexing.

**review**:
@Arelle/arelle
