### PR TITLE
Allow toggling of archive download indexing (off by default)

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -25,6 +25,15 @@ Parameters:
     Default: db.t4g.micro
   DBPassword:
     Type: String
+  EnableIndexingArchiveArchives:
+    Type: String
+    Default: "false"
+  EnableIndexingDailyArchives:
+    Type: String
+    Default: "false"
+  EnableIndexingMonthlyArchives:
+    Type: String
+    Default: "false"
   EnvironmentName:
     Type: String
     Description: "The name of the environment.  Use \"prod\" without quotes for the production environment."
@@ -394,6 +403,12 @@ Resources:
           Value: !Sub "jdbc:postgresql://${RDSDBInstance.Endpoint.Address}:${RDSDBInstance.Endpoint.Port}/${RDSDBInstance.DBName}"
         - Name: "DB_USERNAME"
           Value: !GetAtt RDSDBInstance.MasterUsername
+        - Name: "ENABLE_INDEXING_ARCHIVE_ARCHIVES"
+          Value: !Ref EnableIndexingArchiveArchives
+        - Name: "ENABLE_INDEXING_DAILY_ARCHIVES"
+          Value: !Ref EnableIndexingDailyArchives
+        - Name: "ENABLE_INDEXING_MONTHLY_ARCHIVES"
+          Value: !Ref EnableIndexingMonthlyArchives
         - Name: "FCA_DATA_API_BASE_URL"
           Value: "https://data.fca.org.uk/artefacts/"
         - Name: "FCA_SEARCH_API_URL"

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -221,7 +221,6 @@ public class IndexerImpl implements Indexer {
 	}
 
 	private boolean processCompaniesHouseArchiveUsingTempFile(URI uri, ArchiveType archiveType, String filename, Path tempFile, Set<String> existingCompanyNumbers) {
-		boolean completed = true;
 		LOG.info("Downloading archive: {}", uri);
 		try {
 			this.companiesHouseHistoryClient.downloadArchive(uri, tempFile);
@@ -248,7 +247,6 @@ public class IndexerImpl implements Indexer {
 			Matcher matcher = companiesHouseFilenamePattern.matcher(arcname);
 			if (!matcher.matches()) {
 				LOG.warn("Found invalid archive entry in {}: {}", uri, arcname);
-				completed = false;
 				continue;
 			}
 			String companyNumber = matcher.group(1);
@@ -275,17 +273,13 @@ public class IndexerImpl implements Indexer {
 			LOG.debug("Created company {}.", companyNumber);
 			existingCompanyNumbers.add(companyNumber);
 		}
-		if (completed) {
-			CompaniesHouseArchive archive = CompaniesHouseArchive.builder()
-					.filename(filename)
-					.uri(uri)
-					.archiveType(archiveType.getCode())
-					.build();
-			databaseManager.createCompaniesHouseArchive(archive);
-			LOG.info("Completed archive: {}", filename);
-		} else {
-			LOG.error("Archive not completed: {}", filename);
-		}
+		CompaniesHouseArchive archive = CompaniesHouseArchive.builder()
+				.filename(filename)
+				.uri(uri)
+				.archiveType(archiveType.getCode())
+				.build();
+		databaseManager.createCompaniesHouseArchive(archive);
+		LOG.info("Completed archive: {}", filename);
 		return true;
 	}
 

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -285,27 +285,41 @@ public class IndexerImpl implements Indexer {
 
 	@Scheduled(initialDelay = 5, fixedDelay = 30, timeUnit = TimeUnit.MINUTES)
 	public void indexCompaniesFromCompaniesHouseArchives() {
+		if (!properties.enableIndexingDailyArchives() &&
+				!properties.enableIndexingMonthlyArchives() &&
+				!properties.enableIndexingArchiveArchives()
+		) {
+			return;
+		}
+
 		if (databaseManager.checkCompaniesLimit(properties.unprocessedCompaniesLimit())) {
 			return;
 		}
+
 		var existingCompanyNumbers = new HashSet<String>(databaseManager.getCompaniesCompanyNumbers());
 		List<URI> downloadLinks;
-		downloadLinks = companiesHouseHistoryClient.getDailyDownloadLinks();
-		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, ArchiveType.DAILY, existingCompanyNumbers)) {
-				return;
+		if (properties.enableIndexingDailyArchives()) {
+			downloadLinks = companiesHouseHistoryClient.getDailyDownloadLinks();
+			for (URI uri : downloadLinks) {
+				if (!processCompaniesHouseArchive(uri, ArchiveType.DAILY, existingCompanyNumbers)) {
+					return;
+				}
 			}
 		}
-		downloadLinks = companiesHouseHistoryClient.getMonthlyDownloadLinks();
-		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, ArchiveType.MONTHLY, existingCompanyNumbers)) {
-				return;
+		if (properties.enableIndexingMonthlyArchives()) {
+			downloadLinks = companiesHouseHistoryClient.getMonthlyDownloadLinks();
+			for (URI uri : downloadLinks) {
+				if (!processCompaniesHouseArchive(uri, ArchiveType.MONTHLY, existingCompanyNumbers)) {
+					return;
+				}
 			}
 		}
-		downloadLinks = companiesHouseHistoryClient.getArchiveDownloadLinks();
-		for (URI uri : downloadLinks) {
-			if (!processCompaniesHouseArchive(uri, ArchiveType.ARCHIVE, existingCompanyNumbers)) {
-				return;
+		if (properties.enableIndexingArchiveArchives()) {
+			downloadLinks = companiesHouseHistoryClient.getArchiveDownloadLinks();
+			for (URI uri : downloadLinks) {
+				if (!processCompaniesHouseArchive(uri, ArchiveType.ARCHIVE, existingCompanyNumbers)) {
+					return;
+				}
 			}
 		}
 	}

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -17,6 +17,9 @@ public interface FilingIndexProperties {
 	String companiesHouseStreamApiKey();
 	long companiesHouseStreamIndexerBatchSize();
 	String dbSeedScriptPath();
+	boolean enableIndexingArchiveArchives();
+	boolean enableIndexingDailyArchives();
+	boolean enableIndexingMonthlyArchives();
 	String fcaDataApiBaseUrl();
 	int fcaPastDays();
 	String fcaSearchApiUrl();

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -37,6 +37,9 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String DB_MAX_LIFETIME = "DB_MAX_LIFETIME";
 	private static final String DB_SEED_SCRIPT_PATH = "DB_SEED_SCRIPT_PATH";
 	private static final String DB_HEALTH_CHECK_TIMEOUT = "DB_HEALTH_CHECK_TIMEOUT";
+	private static final String ENABLE_INDEXING_ARCHIVE_ARCHIVES = "ENABLE_INDEXING_ARCHIVE_ARCHIVES";
+	private static final String ENABLE_INDEXING_DAILY_ARCHIVES = "ENABLE_INDEXING_DAILY_ARCHIVES";
+	private static final String ENABLE_INDEXING_MONTHLY_ARCHIVES = "ENABLE_INDEXING_MONTHLY_ARCHIVES";
 	private static final String ENABLE_PREPROCESSING = "ENABLE_PREPROCESSING";
 	private static final String FCA_DATA_API_BASE_URL = "FCA_DATA_API_BASE_URL";
 	private static final String FCA_PAST_DAYS = "FCA_PAST_DAYS";
@@ -69,6 +72,9 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String dbPassword;
 	private final long dbMaxLifetime;
 	private final String dbSeedScriptPath;
+	private final boolean enableIndexingArchiveArchives;
+	private final boolean enableIndexingDailyArchives;
+	private final boolean enableIndexingMonthlyArchives;
 	private final boolean enablePreprocessing;
 	private final String fcaDataApiBaseUrl;
 	private final int fcaPastDays;
@@ -114,6 +120,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		dbPassword = requireNonNull(getEnv(DB_PASSWORD));
 		dbMaxLifetime = Long.parseLong(requireNonNull(getEnv(DB_MAX_LIFETIME, "300000")));
 		dbSeedScriptPath = getEnv(DB_SEED_SCRIPT_PATH);
+
+		enableIndexingArchiveArchives = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_INDEXING_ARCHIVE_ARCHIVES, "false")));
+		enableIndexingDailyArchives = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_INDEXING_DAILY_ARCHIVES, "false")));
+		enableIndexingMonthlyArchives = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_INDEXING_MONTHLY_ARCHIVES, "false")));
 
 		enablePreprocessing = Boolean.parseBoolean(requireNonNull(getEnv(ENABLE_PREPROCESSING, "false")));
 
@@ -251,6 +261,18 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String dbSeedScriptPath() {
 		return dbSeedScriptPath;
+	}
+
+	public boolean enableIndexingArchiveArchives() {
+		return enableIndexingArchiveArchives;
+	}
+
+	public boolean enableIndexingDailyArchives() {
+		return enableIndexingDailyArchives;
+	}
+
+	public boolean enableIndexingMonthlyArchives() {
+		return enableIndexingMonthlyArchives;
 	}
 
 	public boolean enablePreprocessing() {

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -66,6 +66,18 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return null;
 	}
 
+	public boolean enableIndexingArchiveArchives() {
+		return false;
+	}
+
+	public boolean enableIndexingDailyArchives() {
+		return false;
+	}
+
+	public boolean enableIndexingMonthlyArchives() {
+		return false;
+	}
+
 	public boolean enablePreprocessing() {
 		return false;
 	}


### PR DESCRIPTION
#### Reason for change
Archive download indexing is not always desired.

#### Description of change
Allow ability to disable archive download indexing, off by default.
Also, gracefully skip arcnames that do not match the expected pattern.

#### Steps to Test
CI

**review**:
@Arelle/arelle
