### PR TITLE
Support action for deleting a filing

### DIFF
--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -101,11 +101,16 @@ services:
       test: exit 0 # TODO: Improve healthcheck
       timeout: 1s
     environment:
+      AWS_ACCESS_KEY_ID: 'local_aws_access_key_id'
+      AWS_ENDPOINT_URL: 'http://localstack.localhost:4566'
+      AWS_SECRET_ACCESS_KEY: 'local_aws_secret_access_key'
       DB_DATABASE: 'frc_codex'
       DB_HOST: 'postgres.localhost'
       DB_PASSWORD: 'frc_codex'
       DB_PORT: '5432'
       DB_USERNAME: 'frc_codex'
+      S3_RESULTS_BUCKET_NAME: 'frc-codex-results'
+      S3_REGION_NAME: 'eu-west-2'
     platform: linux/amd64
     ports:
       - 8082:8080

--- a/dev/smoke-test.sh
+++ b/dev/smoke-test.sh
@@ -36,6 +36,10 @@ curl $CURL_OPTS http://localhost:8080/admin/smoketest/queue
 echo "Test database page"
 curl $CURL_OPTS http://localhost:8080/admin/smoketest/database
 
+echo "Test support action: delete_filing"
+curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
+  --data '{"action":"delete_filing","filing_id": "cfc59bc3-1899-40ae-87f3-bd199bee8171", "test_mode": true}'
+
 echo "Test support action: get_ch_indexing_stats"
 curl $CURL_OPTS 'localhost:8082/2015-03-31/functions/function/invocations' \
   --data '{"action":"get_ch_indexing_stats"}'

--- a/requirements-support.txt
+++ b/requirements-support.txt
@@ -1,1 +1,2 @@
+boto3==1.37.10
 psycopg2-binary==2.9.10

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -761,6 +761,9 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		if (!StringUtils.isEmpty(searchFilingsRequest.getStatus())) {
 			conditions.add("status = ?");
 			parameters.add(searchFilingsRequest.getStatus());
+		} else {
+			conditions.add("status != ?");
+			parameters.add(FilingStatus.DELETED.toString());
 		}
 		if (!StringUtils.isEmpty(searchFilingsRequest.getRegistryCode())) {
 			conditions.add("registry_code = ?");

--- a/src/main/java/com/frc/codex/model/FilingStatus.java
+++ b/src/main/java/com/frc/codex/model/FilingStatus.java
@@ -4,6 +4,7 @@ public enum FilingStatus {
 	PENDING ("pending"),
 	QUEUED ("queued"),
 	COMPLETED ("completed"),
+	DELETED ("deleted"),
 	FAILED ("failed");
 
 	private final String name;
@@ -14,5 +15,12 @@ public enum FilingStatus {
 
 	public String toString() {
 		return this.name;
+	}
+
+	public static boolean isProcessingAllowed(String name) {
+		return !DELETED.toString().equals(name);
+	}
+	public static boolean isViewerUnavailable(String name) {
+		return FAILED.toString().equals(name) || DELETED.toString().equals(name);
 	}
 }

--- a/support/actions/delete_filing_action.py
+++ b/support/actions/delete_filing_action.py
@@ -1,0 +1,64 @@
+import os
+
+import boto3
+import uuid
+
+from support.actions.base_action import BaseAction
+
+
+class DeleteFilingAction(BaseAction):
+
+    def _run(self, options, cursor) -> tuple[bool, str, list | int | dict]:
+        if 'filing_id' not in options:
+            return False, "Must provide 'filing_id'.", 0
+        filing_id = options['filing_id']
+        try:
+            uuid.UUID(filing_id)
+        except ValueError:
+            return False, f"filing_id must be a valid UUID: {filing_id}", 0
+
+        if 'test_mode' not in options:
+            return False, "Must provide 'test_mode'.", 0
+        test_mode = bool(options['test_mode'])
+
+        if test_mode:
+            query = "SELECT COUNT(*) as count FROM filings WHERE filing_id = %s AND status != 'deleted';"
+            cursor.execute(query, (filing_id,))
+            stats = BaseAction.collect_stats(cursor)
+            rows_affected = stats['count']
+            message = f"Test matched {rows_affected} filing(s) to change status to 'deleted'."
+            deleted_items = self.delete_subfolder(filing_id, True)
+            message += f" Test matched {len(deleted_items)} item(s) to delete from S3."
+        else:
+            query = "UPDATE filings SET status = 'deleted' WHERE filing_id = %s AND status != 'deleted';"
+            cursor.execute(query, (filing_id,))
+            rows_affected = cursor.rowcount
+            message = f"Changed {rows_affected} filing(s) status to 'deleted'."
+            deleted_items = self.delete_subfolder(filing_id, False)
+            message += f" Deleted {len(deleted_items)} item(s) from S3."
+        return True, message, {
+            'deleted_items': deleted_items,
+            'rows_affected': rows_affected,
+            'test_mode': test_mode,
+        }
+
+    def delete_subfolder(self, subfolder_key: str, test_mode: bool) -> list[tuple[str, str]]:
+        region_name = os.getenv('S3_REGION_NAME')
+        bucket_name = os.getenv('S3_RESULTS_BUCKET_NAME')
+        s3_client = boto3.client(
+            's3',
+            region_name=region_name,
+        )
+
+        # List objects in the subfolder
+        response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=subfolder_key)
+
+        deleted_items = []
+        # Delete each object in the subfolder
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                key = obj['Key']
+                if not test_mode:
+                    s3_client.delete_object(Bucket=bucket_name, Key=key)
+                deleted_items.append((bucket_name, key))
+        return deleted_items

--- a/support/actions/delete_filing_action.py
+++ b/support/actions/delete_filing_action.py
@@ -43,8 +43,8 @@ class DeleteFilingAction(BaseAction):
         }
 
     def delete_subfolder(self, subfolder_key: str, test_mode: bool) -> list[tuple[str, str]]:
-        region_name = os.getenv('S3_REGION_NAME')
-        bucket_name = os.getenv('S3_RESULTS_BUCKET_NAME')
+        region_name = str(os.getenv('S3_REGION_NAME'))
+        bucket_name = str(os.getenv('S3_RESULTS_BUCKET_NAME'))
         s3_client = boto3.client(
             's3',
             region_name=region_name,
@@ -57,7 +57,7 @@ class DeleteFilingAction(BaseAction):
         # Delete each object in the subfolder
         if 'Contents' in response:
             for obj in response['Contents']:
-                key = obj['Key']
+                key = str(obj['Key'])
                 if not test_mode:
                     s3_client.delete_object(Bucket=bucket_name, Key=key)
                 deleted_items.append((bucket_name, key))

--- a/support/lambda_function.py
+++ b/support/lambda_function.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from support.actions.delete_filing_action import DeleteFilingAction
 from support.actions.get_ch_indexing_stats_action import GetChIndexingStatsAction
 from support.actions.get_ch_streaming_stats_action import GetChStreamingStatsAction
 from support.actions.get_filing_details_action import GetFilingDetailsAction
@@ -13,6 +14,7 @@ from support.actions.reset_stream_events_action import ResetStreamEventsAction
 logger = logging.getLogger(__name__)
 
 ACTIONS_MAP = {
+    'delete_filing': DeleteFilingAction,
     'get_ch_indexing_stats': GetChIndexingStatsAction,
     'get_ch_streaming_stats': GetChStreamingStatsAction,
     'get_filing_details': GetFilingDetailsAction,


### PR DESCRIPTION
#### Reason for change
Filings may need to be hidden from the index and their assets deleted.

#### Description of change
Add support action for deleting filings


#### Steps to Test
CI (smoke test added)
Locally: select a filing to delete and generate it. Open up one or more associated asset URLs.
Invoke new support action, first with test mode:
```
curl -XPOST "http://localhost:8082/2015-03-31/functions/function/invocations" -d '{"action": "delete_filing", "filing_id": "2e0306f2-7ebf-4889-9370-1fd253957816", "test_mode": true}'
```
Expected output: 
```
Test matched 1 filing(s) to change status to 'deleted'. Test matched 5 item(s) to delete from S3.
```
Then again without test mode:
```
curl -XPOST "http://localhost:8082/2015-03-31/functions/function/invocations" -d '{"action": "delete_filing", "filing_id": "2e0306f2-7ebf-4889-9370-1fd253957816", "test_mode": false}'
```
Expected output:
```
Changed 1 filing(s) status to 'deleted'. Deleted 5 item(s) from S3.
```

Attempt to search for the filing, confirm it no longer appears.
Attempt to load via `/viewer`, `/loading`, `/wait`, `/download` endpoints. Confirm generation is not triggered.
Attempt to load asset URLs. Confirm none are found.

**review**:
@Arelle/arelle
