### PR TITLE
Automatically scroll to the first result if results exist on page

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -318,6 +318,16 @@
         sessionStorage.setItem('ixbrl-viewer-home-link-query', query);
     }
 </script>
+<script>
+    // Scroll to search result, if on page
+    const element = document.getElementById('result-0');
+    if (element) {
+        element.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+        });
+    }
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
#### Reason for change
Search results are not immediately visible on smaller screens.

#### Description of change
Automatically scroll to the first result if results exist on page

#### Steps to Test
![Mar-13-2025 13-36-49](https://github.com/user-attachments/assets/0d86a735-3c41-4301-bd2a-7b54778c0763)

**review**:
@Arelle/arelle
