### PR TITLE
Fix log metric regex

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -965,7 +965,7 @@ Resources:
     Properties:
       ApplyOnTransformedLogs: false
       FilterName: !Sub "${EnvironmentName}-processor-error-metric-filter"
-      FilterPattern: "%[ERROR]%"
+      FilterPattern: "%\\[ERROR\\]%"
       LogGroupName: !Sub "/aws/lambda/${EnvironmentName}-processor"
       MetricTransformations:
         - DefaultValue: 0


### PR DESCRIPTION
#### Reason for change
Processor metric regex matches logs with any char from "E", "R", or "O". It should match `[ERROR]` explicitly.

#### Description of change
Update regex.

#### Steps to Test
* Deploy to dev (already done).
* Verify alarm doesn't fire on every generation.

**review**:
@Arelle/arelle
