### PR TITLE
Protect against unexpected latest timepoint of 0

### DIFF
--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
@@ -64,7 +64,7 @@ public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamLis
 			companiesHouseSessionEventCount++;
 			return true; // Continue streaming
 		};
-		long startTimepoint = databaseManager.getLatestStreamTimepoint(null);
+		Long startTimepoint = databaseManager.getLatestStreamTimepoint(null);
 		companiesHouseStreamLastOpenedDate = new Date();
 		try {
 			companiesHouseClient.streamFilings(startTimepoint, callback);


### PR DESCRIPTION
#### Description of change
Ensure "latest timepoint" result is never 0

#### Steps to Test
CI

**review**:
@Arelle/arelle
