### PR TITLE
Catch HttpStatusCodeException instead of HttpClientErrorException

### DIFF
--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseClientImpl.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -110,7 +110,7 @@ public class CompaniesHouseClientImpl implements CompaniesHouseClient {
 		String json;
 		try {
 			json = information.get("/company/" + companyNumber + "/filing-history/" + filingId);
-		} catch (HttpClientErrorException e) {
+		} catch (HttpStatusCodeException e) {
 			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
 				LOG.warn("Filing not found: companyNumber={} filingId={}", companyNumber, filingId, e);
 				return Set.of();

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseCompaniesIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseCompaniesIndexerImpl.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.frc.codex.clients.companieshouse.CompaniesHouseCompaniesIndexer;
@@ -110,7 +110,7 @@ public class CompaniesHouseCompaniesIndexerImpl implements CompaniesHouseCompani
 			for (Company company : companies) {
 				runCompany(company, continueCallback);
 			}
-		} catch (HttpClientErrorException e) {
+		} catch (HttpStatusCodeException e) {
 			if (e.getStatusCode().is5xxServerError()) {
 				LOG.warn("Companies House API responded with a 5xx server error.", e);
 				return;

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseHttpClient.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseHttpClient.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 import com.frc.codex.clients.companieshouse.CompaniesHouseRateLimiter;
@@ -54,7 +54,7 @@ public class CompaniesHouseHttpClient {
 					this.getJsonEntity,
 					String.class
 			);
-		} catch (HttpClientErrorException e) {
+		} catch (HttpStatusCodeException e) {
 			if (e.getStatusCode() == HttpStatusCode.valueOf(429)) {
 				rateLimiter.notifyRejection();
 				LOG.error("Companies House API rate limit exceeded with 429 response.", e);

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
@@ -160,7 +160,7 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 			} catch (RateLimitException e) {
 				LOG.warn("Rate limit exceeded while streaming CH filings. Resuming later.", e);
 				break;
-			} catch (HttpClientErrorException e) {
+			} catch (HttpStatusCodeException e) {
 				if (e.getStatusCode().is5xxServerError()) {
 					LOG.warn("Companies House API responded with a 5xx server error.", e);
 					return;

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamListenerImpl.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 
 import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
@@ -71,7 +71,7 @@ public class CompaniesHouseStreamListenerImpl implements CompaniesHouseStreamLis
 			companiesHouseClient.streamFilings(startTimepoint, callback);
 		} catch (RateLimitException e) {
 			LOG.warn("Rate limit exceeded while streaming CH filings. Resuming later.", e);
-		} catch (HttpClientErrorException e) {
+		} catch (HttpStatusCodeException e) {
 			if (e.getStatusCode().is5xxServerError()) {
 				LOG.warn("Companies House API responded with a 5xx server error.", e);
 				return;


### PR DESCRIPTION
#### Reason for change
`HttpClientErrorException` is needlessly specific for catching general HTTP exceptions.

#### Description of change
Catch `HttpStatusCodeException` instead.

#### Steps to Test
CI

**review**:
@Arelle/arelle
