### PR TITLE
Increase Lambda Processor Ephemeral Storage

### DIFF
--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -20,6 +20,9 @@ Parameters:
     Type: Number
     Default: 1000
     Description: "The number of stream events to process during each run of the stream indexer."
+  DBAllocatedStorage:
+    Type: String
+    Default: "20"
   DBInstanceClass:
     Type: String
     Default: db.t4g.micro
@@ -719,7 +722,7 @@ Resources:
     Type: "AWS::RDS::DBInstance"
     DeletionPolicy: "Retain"
     Properties:
-      AllocatedStorage: "20"
+      AllocatedStorage: !Ref DBAllocatedStorage
       AutoMinorVersionUpgrade: true
       BackupRetentionPeriod: 7
       CopyTagsToSnapshot: true

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -76,7 +76,7 @@ Parameters:
     Description: "The memory allocated for the lambda processor."
   ProcessorStorageMB:
     Type: String
-    Default: "1024"
+    Default: "2048"
     Description: "The ephemeral storage allocated for the lambda processor."
   ServerAlarmPeriod:
     Type: Number

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -22,7 +22,7 @@ Parameters:
     Description: "The number of stream events to process during each run of the stream indexer."
   DBAllocatedStorage:
     Type: String
-    Default: "20"
+    Default: "30"
   DBInstanceClass:
     Type: String
     Default: db.t4g.micro
@@ -68,7 +68,7 @@ Parameters:
     Description: "Length of processor alarm period in seconds."
   ProcessorAlarmThreshold:
     Type: Number
-    Default: 1
+    Default: 0
     Description: "The number of processor errors to exceed before triggering alarm."
   ProcessorImage:
     Type: String
@@ -87,7 +87,7 @@ Parameters:
     Description: "Length of server alarm period in seconds."
   ServerAlarmThreshold:
     Type: Number
-    Default: 1
+    Default: 0
     Description: "The number of server errors to exceed before triggering alarm."
   ServerImage:
     Type: String
@@ -103,10 +103,10 @@ Parameters:
     Default: 390403885523.dkr.ecr.eu-west-2.amazonaws.com/frc-codex/support
   ServerMillivCPU:
     Type: String
-    Default: "512"
+    Default: "1024"
   ServerMemoryMB:
     Type: String
-    Default: "3072"
+    Default: "2048"
   Version:
     Type: String
     Description: "The docker tag to use.  See ECR for available tags."

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -70,6 +70,14 @@ Parameters:
   ProcessorImage:
     Type: String
     Default: 390403885523.dkr.ecr.eu-west-2.amazonaws.com/frc-codex/processor-lambda
+  ProcessorMemoryMB:
+    Type: String
+    Default: "3008"
+    Description: "The memory allocated for the lambda processor."
+  ProcessorStorageMB:
+    Type: String
+    Default: "1024"
+    Description: "The ephemeral storage allocated for the lambda processor."
   ServerAlarmPeriod:
     Type: Number
     Default: 300
@@ -797,11 +805,11 @@ Resources:
           S3_TAXONOMY_PACKAGES_BUCKET_NAME: !Ref S3TaxonomyPackagesBucket
           SERVICE_VERSION: !Ref Version
       EphemeralStorage:
-        Size: 1024
+        Size: !Ref ProcessorStorageMB
       LoggingConfig:
         LogFormat: "Text"
         LogGroup: !Sub "/aws/lambda/${EnvironmentName}-processor"
-      MemorySize: 3008
+      MemorySize: !Ref ProcessorMemoryMB
       Role: !GetAtt IAMRoleProcessorLambda.Arn
       PackageType: "Image"
       RecursiveLoop: "Terminate"


### PR DESCRIPTION
#### Reason for change
A new large FCA filing caused the lambda processor to run out of disk space and fail.

#### Description of change
* Configure Lambda Processor memory and storage limits using parameters.
* Increase processor lambda storage limit.
* Configure DB storage using parameter.
* Update CloudFormation defaults to match prod env.
* Update DB storage setting to match "drifted" DB in prod.

#### Steps to Test
* [x] Deployed and test in dev.

**review**:
@Arelle/arelle
