### PR TITLE
Upload stream metrics to CloudWatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security:3.4.4'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.4.4'
 	implementation 'org.springframework.boot:spring-boot-starter-web:3.4.4'
+	implementation 'software.amazon.awssdk:cloudwatch:2.31.21'
 	implementation 'software.amazon.awssdk:lambda:2.31.21'
 	implementation 'software.amazon.awssdk:netty-nio-client:2.31.21'
 	implementation 'software.amazon.awssdk:s3:2.31.21'

--- a/deploy/cfn.yml
+++ b/deploy/cfn.yml
@@ -436,7 +436,9 @@ Resources:
           Value: "-XX:MaxRAMPercentage=80"
         - Name: "LAMBDA_PREPROCESSING_CONCURRENCY"
           Value: !Ref LambdaPreprocessingConcurrency
-        - Name: S3_TAXONOMY_PACKAGES_BUCKET_NAME
+        - Name: "METRIC_NAMESPACE"
+          Value: !Sub "${EnvironmentName}-server"
+        - Name: "S3_TAXONOMY_PACKAGES_BUCKET_NAME"
           Value: !Ref S3TaxonomyPackagesBucket
         - Name: "SQS_JOBS_QUEUE_NAME"
           Value: unused
@@ -446,6 +448,10 @@ Resources:
           Value: !Ref S3ResultsBucket
         - Name: "SQS_RESULTS_QUEUE_NAME"
           Value: unused
+        - Name: "STREAM_DISCOVERY_DELAY_METRIC"
+          Value: !Sub "${EnvironmentName}-server-stream-discovery-delay"
+        - Name: "STREAM_EVENTS_METRIC"
+          Value: !Sub "${EnvironmentName}-server-stream-events"
         - Name: "SUPPORT_EMAIL"
           Value: !Ref SupportEmail
         - Name: "UNPROCESSED_COMPANIES_LIMIT"

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -28,10 +28,13 @@ services:
       FCA_DATA_API_BASE_URL: "https://data.fca.org.uk/artefacts/"
       FCA_SEARCH_API_URL: "https://api.data.fca.org.uk/search?index=fca-nsm-searchdata"
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,address=*:8180,suspend=n"
+      METRIC_NAMESPACE: 'frc-codex'
       S3_INDEXER_UPLOADS_BUCKET_NAME: "frc-codex-indexer-uploads"
       S3_RESULTS_BUCKET_NAME: "frc-codex-results"
       SQS_JOBS_QUEUE_NAME: "frc_codex_jobs"
       SQS_RESULTS_QUEUE_NAME: "frc_codex_results"
+      STREAM_EVENTS_METRIC: "stream-events"
+      STREAM_DISCOVERY_DELAY_METRIC: "stream-discovery-delay"
       SUPPORT_EMAIL: "dev@localhost"
     secrets:
       - frc-codex-server.secrets

--- a/src/main/java/com/frc/codex/database/DatabaseManager.java
+++ b/src/main/java/com/frc/codex/database/DatabaseManager.java
@@ -34,10 +34,12 @@ public interface DatabaseManager {
 	List<Filing> getFilingsByStatus(FilingStatus status, RegistryCode registryCode);
 	long getFilingsCount(SearchFilingsRequest searchFilingsRequest);
 	LocalDateTime getLatestFcaFilingDate(LocalDateTime defaultDate);
+	LocalDateTime getLatestStreamDiscoveredDate();
 	Long getLatestStreamTimepoint(Long defaultTimepoint);
 	long getRegistryCount(RegistryCode registryCode);
 	void resetCompany(String companyNumber);
 	List<StreamEvent> getStreamEvents(long limit);
+	long getStreamEventsCount();
 	void resetFiling(UUID filingId);
 	List<Filing> searchFilings(SearchFilingsRequest searchFilingsRequest);
 	void updateFilingStatus(UUID filingId, String status);

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -345,6 +345,21 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		}
 	}
 
+	public LocalDateTime getLatestStreamDiscoveredDate() {
+		try (Connection connection = getInitializedConnection(true)) {
+			String sql = "SELECT MAX(discovered_date) FROM filings WHERE stream_timepoint IS NOT NULL";
+			PreparedStatement statement = connection.prepareStatement(sql);
+			ResultSet resultSet = statement.executeQuery();
+			LocalDateTime result = null;
+			if (resultSet.next()) {
+				result = getLocalDateTime(resultSet.getTimestamp(1));
+			}
+			return result;
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	private Long getLatestFilingTimepoint() {
 		try (Connection connection = getInitializedConnection(true)) {
 			PreparedStatement statement = connection.prepareStatement(
@@ -453,6 +468,18 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 			statement.setLong(1, limit);
 			ResultSet resultSet = statement.executeQuery();
 			return getStreamEvents(resultSet);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public long getStreamEventsCount() {
+		try (Connection connection = getInitializedConnection(true)) {
+			String sql = "SELECT COUNT(*) FROM stream_events;";
+			PreparedStatement statement = connection.prepareStatement(sql);
+			ResultSet resultSet = statement.executeQuery();
+			resultSet.next();
+			return resultSet.getLong(1);
 		} catch (SQLException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/com/frc/codex/indexer/MetricManager.java
+++ b/src/main/java/com/frc/codex/indexer/MetricManager.java
@@ -1,0 +1,5 @@
+package com.frc.codex.indexer;
+
+public interface MetricManager {
+	void uploadMetrics();
+}

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -44,6 +44,7 @@ import com.frc.codex.database.DatabaseManager;
 import com.frc.codex.indexer.Indexer;
 import com.frc.codex.indexer.IndexerJob;
 import com.frc.codex.indexer.LambdaManager;
+import com.frc.codex.indexer.MetricManager;
 import com.frc.codex.indexer.QueueManager;
 import com.frc.codex.indexer.UploadIndexer;
 import com.frc.codex.model.ArchiveType;
@@ -72,6 +73,7 @@ public class IndexerImpl implements Indexer {
 	private final FcaClient fcaClient;
 	private final List<IndexerJob> jobs;
 	private final LambdaManager lambdaManager;
+	private final MetricManager metricManager;
 	private final FilingIndexProperties properties;
 	private final QueueManager queueManager;
 	private final UploadIndexer uploadIndexer;
@@ -90,6 +92,7 @@ public class IndexerImpl implements Indexer {
 			FcaClient fcaClient,
 			FilingIndexProperties properties,
 			LambdaManager lambdaManager,
+			MetricManager metricManager,
 			QueueManager queueManager,
 			UploadIndexer uploadIndexer
 
@@ -102,6 +105,7 @@ public class IndexerImpl implements Indexer {
 		this.databaseManager = databaseManager;
 		this.fcaClient = fcaClient;
 		this.lambdaManager = lambdaManager;
+		this.metricManager = metricManager;
 		this.properties = properties;
 		this.queueManager = queueManager;
 		this.uploadIndexer = uploadIndexer;
@@ -458,5 +462,13 @@ public class IndexerImpl implements Indexer {
 		queueManager.addJobs(filings, (Filing filing) -> {
 			databaseManager.updateFilingStatus(filing.getFilingId(), FilingStatus.QUEUED.toString());
 		});
+	}
+
+	/*
+	 * Calculates and uploads metrics on an approximate one-minute interval
+	 */
+	@Scheduled(initialDelay = 30, fixedDelay = 60, timeUnit = TimeUnit.SECONDS)
+	public void uploadMetrics() {
+		metricManager.uploadMetrics();
 	}
 }

--- a/src/main/java/com/frc/codex/indexer/impl/LambdaManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/LambdaManagerImpl.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 
 @Component
 public class LambdaManagerImpl implements LambdaManager {
-	private static final Logger LOG = LoggerFactory.getLogger(IndexerImpl.class);
+	private static final Logger LOG = LoggerFactory.getLogger(LambdaManagerImpl.class);
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private final LambdaAsyncClient client;
 	private final FilingIndexProperties properties;

--- a/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/MetricManagerImpl.java
@@ -1,0 +1,70 @@
+package com.frc.codex.indexer.impl;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.frc.codex.database.DatabaseManager;
+import com.frc.codex.indexer.MetricManager;
+import com.frc.codex.properties.FilingIndexProperties;
+
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataResponse;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+
+@Component
+public class MetricManagerImpl implements MetricManager {
+	private static final Logger LOG = LoggerFactory.getLogger(MetricManagerImpl.class);
+	private final CloudWatchClient client;
+	private final DatabaseManager databaseManager;
+	private final FilingIndexProperties properties;
+
+	public MetricManagerImpl(DatabaseManager databaseManager, FilingIndexProperties properties) {
+		this.databaseManager = databaseManager;
+		this.properties = properties;
+		this.client = CloudWatchClient.create();
+	}
+
+	public void uploadMetrics() {
+		if (this.properties.metricNamespace() == null) {
+			LOG.debug("No metric namespace configured, skipping metric upload");
+			return;
+		}
+		PutMetricDataRequest.Builder requestBuilder = PutMetricDataRequest.builder()
+				.namespace(this.properties.metricNamespace());
+		if (this.properties.streamEventsMetric() != null) {
+			long streamEventsCount = this.databaseManager.getStreamEventsCount();
+			LOG.debug("Uploading metric: streamEventsCount={}", streamEventsCount);
+			requestBuilder.metricData(MetricDatum.builder()
+					.metricName(this.properties.streamEventsMetric())
+					.value((double) streamEventsCount)
+					.unit(StandardUnit.COUNT)
+					.build());
+		}
+		if (this.properties.streamDiscoveryDelayMetric() != null) {
+			LocalDateTime latestStreamDiscoveredDate = this.databaseManager.getLatestStreamDiscoveredDate();
+			int streamDiscoveryDelay = 0;
+			if (latestStreamDiscoveredDate != null) {
+				streamDiscoveryDelay = (int) Duration.between(latestStreamDiscoveredDate, LocalDateTime.now()).toSeconds();
+				if (streamDiscoveryDelay < 0) {
+					streamDiscoveryDelay = 0;
+				}
+			}
+			LOG.debug("Uploading metric: streamDiscoveryDelay={}", streamDiscoveryDelay);
+			requestBuilder.metricData(MetricDatum.builder()
+					.metricName(this.properties.streamDiscoveryDelayMetric())
+					.value((double) streamDiscoveryDelay)
+					.unit(StandardUnit.SECONDS)
+					.build());
+		}
+		PutMetricDataResponse response = this.client.putMetricData(requestBuilder.build());
+		if (!response.sdkHttpResponse().isSuccessful()) {
+			LOG.error("Failed to upload metric: {} {}",response.sdkHttpResponse().statusCode(), response.sdkHttpResponse().statusText());
+		}
+	}
+}

--- a/src/main/java/com/frc/codex/indexer/impl/QueueManagerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/QueueManagerImpl.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 @Component
 public class QueueManagerImpl implements QueueManager {
-	private static final Logger LOG = LoggerFactory.getLogger(IndexerImpl.class);
+	private static final Logger LOG = LoggerFactory.getLogger(QueueManagerImpl.class);
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private final FilingIndexProperties properties;

--- a/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
+++ b/src/main/java/com/frc/codex/properties/FilingIndexProperties.java
@@ -32,12 +32,15 @@ public interface FilingIndexProperties {
 	boolean isAws();
 	boolean isDbMigrateAsync();
 	int lambdaPreprocessingConcurrency();
+	String metricNamespace();
 	String s3IndexerUploadsBucketName();
 	String s3ResultsBucketName();
 	int searchMaximumPages();
 	int searchPageSize();
 	String sqsJobsQueueName();
 	String sqsResultsQueueName();
+	String streamDiscoveryDelayMetric();
+	String streamEventsMetric();
 	String supportEmail();
 	int dbHealthCheckTimeout();
 

--- a/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
+++ b/src/main/java/com/frc/codex/properties/impl/FilingIndexPropertiesImpl.java
@@ -47,6 +47,7 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String FILING_LIMIT_COMPANIES_HOUSE = "FILING_LIMIT_COMPANIES_HOUSE";
 	private static final String FILING_LIMIT_FCA = "FILING_LIMIT_FCA";
 	private static final String LAMBDA_PREPROCESSING_CONCURRENCY = "LAMBDA_PREPROCESSING_CONCURRENCY";
+	private static final String METRIC_NAMESPACE = "METRIC_NAMESPACE";
 	private static final String S3_INDEXER_UPLOADS_BUCKET_NAME = "S3_INDEXER_UPLOADS_BUCKET_NAME";
 	private static final String S3_RESULTS_BUCKET_NAME = "S3_RESULTS_BUCKET_NAME";
 	private static final String SEARCH_MAXIMUM_PAGES = "SEARCH_MAXIMUM_PAGES";
@@ -54,6 +55,8 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private static final String SECRETS_FILEPATH = "/run/secrets/frc-codex-server.secrets";
 	private static final String SQS_JOBS_QUEUE_NAME = "SQS_JOBS_QUEUE_NAME";
 	private static final String SQS_RESULTS_QUEUE_NAME = "SQS_RESULTS_QUEUE_NAME";
+	private static final String STREAM_DISCOVERY_DELAY_METRIC = "STREAM_DISCOVERY_DELAY_METRIC";
+	private static final String STREAM_EVENTS_METRIC = "STREAM_EVENTS_METRIC";
 	private static final String SUPPORT_EMAIL = "SUPPORT_EMAIL";
 	private static final String UNPROCESSED_COMPANIES_LIMIT = "UNPROCESSED_COMPANIES_LIMIT";
 	private final String adminCookieName;
@@ -85,12 +88,15 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 	private final String awsLambdaFunctionName;
 	private final long awsLambdaTimeoutSeconds;
 	private final int lambdaPreprocessingConcurrency;
+	private final String metricNamespace;
 	private final String s3IndexerUploadsBucketName;
 	private final String s3ResultsBucketName;
 	private final int searchMaximumPages;
 	private final int searchPageSize;
 	private final String sqsJobsQueueName;
 	private final String sqsResultsQueueName;
+	private final String streamDiscoveryDelayMetric;
+	private final String streamEventsMetric;
 	private final String supportEmail;
 	private final int unprocessedCompaniesLimit;
 	private final String httpUsername;
@@ -139,6 +145,8 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 		lambdaPreprocessingConcurrency = Integer.parseInt(requireNonNull(getEnv(LAMBDA_PREPROCESSING_CONCURRENCY, "1")));
 
+		metricNamespace = requireNonNull(getEnv(METRIC_NAMESPACE, null));
+
 		searchMaximumPages = Integer.parseInt(requireNonNull(getEnv(SEARCH_MAXIMUM_PAGES, "10")));
 		searchPageSize = Integer.parseInt(requireNonNull(getEnv(SEARCH_PAGE_SIZE, "10")));
 
@@ -146,6 +154,9 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		s3ResultsBucketName = requireNonNull(getEnv(S3_RESULTS_BUCKET_NAME));
 		sqsJobsQueueName = requireNonNull(getEnv(SQS_JOBS_QUEUE_NAME));
 		sqsResultsQueueName = requireNonNull(getEnv(SQS_RESULTS_QUEUE_NAME));
+
+		streamDiscoveryDelayMetric = requireNonNull(getEnv(STREAM_DISCOVERY_DELAY_METRIC, null));
+		streamEventsMetric = requireNonNull(getEnv(STREAM_EVENTS_METRIC, null));
 
 		supportEmail = getEnv(SUPPORT_EMAIL, null);
 
@@ -332,6 +343,10 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 		return lambdaPreprocessingConcurrency;
 	}
 
+	public String metricNamespace() {
+		return metricNamespace;
+	}
+
 	public String s3IndexerUploadsBucketName() {
 		return s3IndexerUploadsBucketName;
 	}
@@ -354,6 +369,14 @@ public class FilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String sqsResultsQueueName() {
 		return sqsResultsQueueName;
+	}
+
+	public String streamDiscoveryDelayMetric() {
+		return streamDiscoveryDelayMetric;
+	}
+
+	public String streamEventsMetric() {
+		return streamEventsMetric;
 	}
 
 	public String supportEmail() {

--- a/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
+++ b/src/test/java/com/frc/codex/database/impl/TestDatabaseManagerImpl.java
@@ -79,6 +79,10 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 		return null;
 	}
 
+	public LocalDateTime getLatestStreamDiscoveredDate() {
+		return null;
+	}
+
 	public Long getLatestStreamTimepoint(Long defaultTimepoint) {
 		return defaultTimepoint;
 	}
@@ -103,6 +107,10 @@ public class TestDatabaseManagerImpl implements DatabaseManager {
 
 	public List<StreamEvent> getStreamEvents(long limit) {
 		return null;
+	}
+
+	public long getStreamEventsCount() {
+		return 0;
 	}
 
 	public void resetFiling(UUID filingId) { }

--- a/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
+++ b/src/test/java/com/frc/codex/impl/TestFilingIndexPropertiesImpl.java
@@ -134,6 +134,10 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 		return 1;
 	}
 
+	public String metricNamespace() {
+		return null;
+	}
+
 	public String s3ResultsBucketName() {
 		return "frc-codex-results";
 	}
@@ -156,6 +160,14 @@ public class TestFilingIndexPropertiesImpl implements FilingIndexProperties {
 
 	public String sqsResultsQueueName() {
 		return "frc_codex_results";
+	}
+
+	public String streamDiscoveryDelayMetric() {
+		return null;
+	}
+
+	public String streamEventsMetric() {
+		return null;
 	}
 
 	public String supportEmail() {


### PR DESCRIPTION
#### Reason for change
There's currently no automatic metrics/alarms reporting on the status of the stream indexing. I've been checking manually daily.

#### Description of change
Start pushing metric data:
- How may unprocessed stream events are in the queue?
- How long ago was the last filing discovered by stream indexing?

Alarm will be configured in future PR based on analysis of the metric data.

#### Steps to Test
CI (localstack doesn't appear to actually capture metric data and allow for verification locally)

**review**:
@Arelle/arelle
