### PR TITLE
Support multi-IXDS packages from CoHo

### DIFF
--- a/processor/base/job_message.py
+++ b/processor/base/job_message.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class JobMessage:
     filing_id: str
+    format: str
     download_url: str
     registry_code: str
     receipt_handle: str

--- a/processor/main/main_queue_manager.py
+++ b/processor/main/main_queue_manager.py
@@ -55,6 +55,7 @@ class MainQueueManager(QueueManager):
                 yield JobMessage(
                     download_url=message.message_attributes['DownloadUrl']['StringValue'],
                     filing_id=message.body,
+                    format=message.message_attributes['Format']['StringValue'],
                     message_id=message.message_id,
                     receipt_handle=message.receipt_handle,
                     registry_code=message.message_attributes['RegistryCode']['StringValue'],

--- a/processor/main/workers/ixbrl_viewer_worker.py
+++ b/processor/main/workers/ixbrl_viewer_worker.py
@@ -106,7 +106,7 @@ class IxbrlViewerWorker(Worker):
 
     def _get_plugins(self, job_message: JobMessage) -> list[str]:
         plugins = []
-        if job_message.registry_code != 'CH' or job_message.format != 'zip':
+        if job_message.registry_code != 'CH':
             plugins.append('inlineXbrlDocumentSet')
         plugins.extend([
             'ixbrl-viewer',

--- a/processor/main/workers/ixbrl_viewer_worker.py
+++ b/processor/main/workers/ixbrl_viewer_worker.py
@@ -45,7 +45,9 @@ class IxbrlViewerWorker(Worker):
             taxonomy_package_urls: list[str],
     ) -> WorkerResult:
         assert filing_download.download_path is not None
-        result = self._generate_viewer(job_message, filing_download.download_path, viewer_directory, taxonomy_package_urls)
+        result = self._generate_viewer(
+            job_message, filing_download.download_path, viewer_directory, taxonomy_package_urls
+        )
         if not result.success:
             return WorkerResult(
                 job_message.filing_id,
@@ -112,7 +114,13 @@ class IxbrlViewerWorker(Worker):
         ])
         return plugins
 
-    def _generate_viewer(self, job_message: JobMessage, target_path: Path, viewer_directory: Path, packages: list[str]) -> IxbrlViewerResult:
+    def _generate_viewer(
+            self,
+            job_message: JobMessage,
+            target_path: Path,
+            viewer_directory: Path,
+            packages: list[str]
+    ) -> IxbrlViewerResult:
         runtime_options = RuntimeOptions(
             cacheDirectory=str(self._http_cache_directory),
             disablePersistentConfig=True,

--- a/processor/processor.py
+++ b/processor/processor.py
@@ -130,6 +130,7 @@ class Processor:
 
         job_message = JobMessage(
             filing_id=body['filing_id'],
+            format=body['format'],
             download_url=body['filing_url'],
             registry_code=body['registry_code'],
             receipt_handle=context.aws_request_id,

--- a/processor_tests/test_processor.py
+++ b/processor_tests/test_processor.py
@@ -18,6 +18,7 @@ class TestProcessor(TestCase):
         job_messages = [
             JobMessage(
                 filing_id='filing_id1',
+                format='format1',
                 registry_code='registry_code1',
                 download_url='download_url1',
                 receipt_handle='receipt_handle1',
@@ -25,6 +26,7 @@ class TestProcessor(TestCase):
             ),
             JobMessage(
                 filing_id='filing_id2',
+                format='format2',
                 registry_code='registry_code2',
                 download_url='download_url2',
                 receipt_handle='receipt_handle2',

--- a/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseClient.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/CompaniesHouseClient.java
@@ -2,7 +2,6 @@ package com.frc.codex.clients.companieshouse;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,7 +12,7 @@ public interface CompaniesHouseClient {
 	CompaniesHouseCompany getCompany(String companyNumber) throws JsonProcessingException;
 	CompaniesHouseFiling getFiling(String companyNumber, String transactionId) throws JsonProcessingException;
 	List<NewFilingRequest> getCompanyFilings(String companyNumber, String companyName) throws JsonProcessingException;
-	Set<String> getCompanyFilingUrls(String companyNumber, String filingId) throws JsonProcessingException;
+	FilingUrl getCompanyFilingUrl(String companyNumber, String filingId) throws JsonProcessingException;
 	boolean isEnabled();
 	CompaniesHouseFiling parseStreamedFiling(String json) throws JsonProcessingException;
 	void streamFilings(Long timepoint, Function<String, Boolean> callback) throws IOException, InterruptedException;

--- a/src/main/java/com/frc/codex/clients/companieshouse/FilingFormat.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/FilingFormat.java
@@ -1,0 +1,30 @@
+package com.frc.codex.clients.companieshouse;
+
+public enum FilingFormat {
+	XML ("xhtml", "application/xml", 1),
+	XHTML ("xhtml", "application/xhtml+xml", 2),
+	ZIP ("zip", "application/zip", 3);
+
+	private final String format;
+	private final String contentType;
+	private final int priority;
+
+
+	private FilingFormat(String format, String contentType, int priority) {
+		this.format = format;
+		this.contentType = contentType;
+		this.priority = priority;
+	}
+
+	public String getFormat() {
+		return format;
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public int getPriority() {
+		return priority;
+	}
+}

--- a/src/main/java/com/frc/codex/clients/companieshouse/FilingUrl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/FilingUrl.java
@@ -1,0 +1,19 @@
+package com.frc.codex.clients.companieshouse;
+
+public class FilingUrl {
+	private final FilingFormat filingFormat;
+	private final String downloadUrl;
+
+	public FilingUrl(FilingFormat filingFormat, String downloadUrl) {
+		this.filingFormat = filingFormat;
+		this.downloadUrl = downloadUrl;
+	}
+
+	public FilingFormat getFilingFormat() {
+		return filingFormat;
+	}
+
+	public String getDownloadUrl() {
+		return downloadUrl;
+	}
+}

--- a/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
+++ b/src/main/java/com/frc/codex/clients/companieshouse/impl/CompaniesHouseStreamIndexerImpl.java
@@ -2,7 +2,6 @@ package com.frc.codex.clients.companieshouse.impl;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -16,6 +15,7 @@ import com.frc.codex.clients.companieshouse.CompaniesHouseClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseCompany;
 import com.frc.codex.clients.companieshouse.CompaniesHouseFiling;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamIndexer;
+import com.frc.codex.clients.companieshouse.FilingUrl;
 import com.frc.codex.clients.companieshouse.RateLimitException;
 import com.frc.codex.database.DatabaseManager;
 import com.frc.codex.model.NewFilingRequest;
@@ -87,11 +87,11 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 			return timepoint;
 		}
 		// Check if an IXBRL document is associated with the filing
-		Set<String> filingUrls = companiesHouseClient.getCompanyFilingUrls(
+		FilingUrl filingUrl = companiesHouseClient.getCompanyFilingUrl(
 				companiesHouseFiling.companyNumber(),
 				companiesHouseFiling.resourceId()
 		);
-		if (filingUrls.isEmpty()) {
+		if (filingUrl == null) {
 			LOG.debug("CH filing stream event: Skipped {}, no IXBRL documents.", companiesHouseFiling.transactionId());
 			return timepoint;
 		}
@@ -118,6 +118,7 @@ public class CompaniesHouseStreamIndexerImpl implements CompaniesHouseStreamInde
 				.externalFilingId(companiesHouseFiling.transactionId())
 				.externalViewUrl(companiesHouseFiling.downloadUrl())
 				.filingDate(companiesHouseFiling.date())
+				.format(filingUrl.getFilingFormat().getFormat())
 				.registryCode(RegistryCode.COMPANIES_HOUSE.getCode())
 				.streamTimepoint(companiesHouseFiling.timepoint())
 				.build();

--- a/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
+++ b/src/main/java/com/frc/codex/database/impl/DatabaseManagerImpl.java
@@ -185,12 +185,13 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 		UUID filingId;
 		try (Connection connection = getInitializedConnection(false)) {
 			String sql = "INSERT INTO filings " +
-					"(status, registry_code, download_url, external_filing_id, external_view_url, document_date, filing_date, stream_timepoint, company_name, company_number) " +
-					"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ? ,?)";
+					"(status, registry_code, format, download_url, external_filing_id, external_view_url, document_date, filing_date, stream_timepoint, company_name, company_number) " +
+					"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? ,?)";
 			PreparedStatement statement = connection.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS);
 			int i = 0;
 			statement.setString(++i, FilingStatus.PENDING.toString());
 			statement.setString(++i, newFilingRequest.getRegistryCode());
+			statement.setString(++i, newFilingRequest.getFormat());
 			statement.setString(++i, newFilingRequest.getDownloadUrl());
 			statement.setString(++i, newFilingRequest.getExternalFilingId());
 			statement.setString(++i, newFilingRequest.getExternalViewUrl());
@@ -638,6 +639,7 @@ public class DatabaseManagerImpl implements AutoCloseable, DatabaseManager {
 					.filingDate(getLocalDateTime(
 							resultSet.getTimestamp("filing_date", TIMEZONE_UTC)
 					))
+					.format(resultSet.getString("format"))
 					.documentDate(getLocalDateTime(
 							resultSet.getTimestamp("document_date", TIMEZONE_UTC)
 					))

--- a/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
+++ b/src/main/java/com/frc/codex/indexer/impl/IndexerImpl.java
@@ -38,6 +38,7 @@ import com.frc.codex.clients.companieshouse.CompaniesHouseCompaniesIndexer;
 import com.frc.codex.clients.companieshouse.CompaniesHouseHistoryClient;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamIndexer;
 import com.frc.codex.clients.companieshouse.CompaniesHouseStreamListener;
+import com.frc.codex.clients.companieshouse.FilingFormat;
 import com.frc.codex.clients.fca.FcaClient;
 import com.frc.codex.clients.fca.FcaFiling;
 import com.frc.codex.database.DatabaseManager;
@@ -354,6 +355,7 @@ public class IndexerImpl implements Indexer {
 					.externalFilingId(filing.sequenceId())
 					.externalViewUrl(filing.infoUrl())
 					.filingDate(filing.submittedDate())
+					.format(FilingFormat.ZIP.getFormat())
 					.registryCode(RegistryCode.FCA.getCode())
 					.build();
 			if (databaseManager.filingExists(newFilingRequest.getRegistryCode(), newFilingRequest.getExternalFilingId())) {
@@ -399,6 +401,7 @@ public class IndexerImpl implements Indexer {
 					future = lambdaManager.invokeAsync(new FilingPayload(
 							filing.getFilingId(),
 							filing.getDownloadUrl(),
+							filing.getFormat(),
 							filing.getRegistryCode()
 					));
 					futures[i] = future;

--- a/src/main/java/com/frc/codex/model/Filing.java
+++ b/src/main/java/com/frc/codex/model/Filing.java
@@ -6,6 +6,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.frc.codex.clients.companieshouse.FilingFormat;
+
 public class Filing {
 	private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
@@ -21,6 +23,7 @@ public class Filing {
 	private final String filename;
 	private final String filingType;
 	private final LocalDateTime filingDate;
+	private final String format;
 	private final LocalDateTime documentDate;
 	private final Long streamTimepoint;
 	private final String error;
@@ -42,6 +45,7 @@ public class Filing {
 		this.filename = b.filename;
 		this.filingType = b.filingType;
 		this.filingDate = b.filingDate;
+		this.format = b.format;
 		this.documentDate = b.documentDate;
 		this.streamTimepoint = b.streamTimepoint;
 		this.error = b.error;
@@ -120,6 +124,14 @@ public class Filing {
 		return filingDate;
 	}
 
+	public String getFormat() {
+		if (format == null) {
+			// For backwards compatability, null format defaults to XHTML
+			return FilingFormat.XHTML.getFormat();
+		}
+		return format;
+	}
+
 	public LocalDateTime getDocumentDate() {
 		return documentDate;
 	}
@@ -193,6 +205,7 @@ public class Filing {
 		private String filename;
 		private String filingType;
 		private LocalDateTime filingDate;
+		private String format;
 		private LocalDateTime documentDate;
 		private Long streamTimepoint;
 		private String error;
@@ -263,6 +276,11 @@ public class Filing {
 
 		public Builder filingDate(LocalDateTime filingDate) {
 			this.filingDate = filingDate;
+			return this;
+		}
+
+		public Builder format(String format) {
+			this.format = format;
 			return this;
 		}
 

--- a/src/main/java/com/frc/codex/model/FilingPayload.java
+++ b/src/main/java/com/frc/codex/model/FilingPayload.java
@@ -5,12 +5,13 @@ import java.util.UUID;
 public record FilingPayload (
 		UUID filingId,
 		String filingUrl,
+		String format,
 		String registryCode) {
 
 	public String toString() {
 		return String.format(
-				"{\"filing_id\": \"%s\", \"filing_url\": \"%s\", \"registry_code\": \"%s\"}",
-				filingId.toString(), filingUrl, registryCode
+				"{\"filing_id\": \"%s\", \"filing_url\": \"%s\", \"format\": \"%s\", \"registry_code\": \"%s\"}",
+				filingId.toString(), filingUrl, format, registryCode
 		);
 	}
 }

--- a/src/main/java/com/frc/codex/model/NewFilingRequest.java
+++ b/src/main/java/com/frc/codex/model/NewFilingRequest.java
@@ -12,6 +12,7 @@ public class NewFilingRequest {
 	private final String downloadUrl;
 	private final String externalFilingId;
 	private final LocalDateTime filingDate;
+	private final String format;
 	private final String resourceId;
 	private final Long streamTimepoint;
 	private final String externalViewUrl;
@@ -24,6 +25,7 @@ public class NewFilingRequest {
 		this.externalFilingId = requireNonNull(builder.externalFilingId);
 		this.externalViewUrl = requireNonNull(builder.externalViewUrl);
 		this.filingDate = requireNonNull(builder.filingDate);
+		this.format = requireNonNull(builder.format);
 		this.registryCode = requireNonNull(builder.registryCode);
 		this.resourceId = builder.resourceId;
 		this.streamTimepoint = builder.streamTimepoint;
@@ -57,6 +59,10 @@ public class NewFilingRequest {
 		return filingDate;
 	}
 
+	public String getFormat() {
+		return format;
+	}
+
 	public String getRegistryCode() {
 		return registryCode;
 	}
@@ -81,6 +87,7 @@ public class NewFilingRequest {
 		private String downloadUrl;
 		private String externalFilingId;
 		private LocalDateTime filingDate;
+		private String format;
 		private String resourceId;
 		private Long streamTimepoint;
 		private String externalViewUrl;
@@ -121,6 +128,11 @@ public class NewFilingRequest {
 
 		public Builder filingDate(LocalDateTime filingDate) {
 			this.filingDate = filingDate;
+			return this;
+		}
+
+		public Builder format(String format) {
+			this.format = format;
 			return this;
 		}
 

--- a/src/main/resources/db/migration/V12__filings_format.sql
+++ b/src/main/resources/db/migration/V12__filings_format.sql
@@ -1,0 +1,2 @@
+ALTER TABLE filings
+    ADD COLUMN format VARCHAR(40);


### PR DESCRIPTION
#### Reason for change
We've recently encountered a handful of multi-ixds zip filings from CoHo, which was not fully supported.

#### Description of change
- Store the format of a filing for easier decision making on how to process and preview filings
- Don't show preview for zip filings from CoHo
- Special handling in processor for zip filings from CoHo

#### Steps to Test
Insert a filing into the index and view/download each of the assets, paying special attention to the preview page on initial generation:
```
INSERT INTO filings (registry_code, status, download_url, company_name, company_number, external_filing_id, external_view_url, filing_date, document_date, format)
VALUES (
		'CH', 'pending', 'https://find-and-update.company-information.service.gov.uk/company/12162403/filing-history/MzQ2NTc3NzkzNWFkaXF6a2N4/document?format=zip&download=0', 'SPORTING PILLARS C.I.C.', '12162403',
		'MzQ2NTc3NzkzNWFkaXF6a2N4', 'https://find-and-update.company-information.service.gov.uk/company/12162403/filing-history/MzQ2NTc3NzkzNWFkaXF6a2N4/document?format=zip&download=0',
		'2025-05-13', '2025-05-13', 'zip'
)
```
**review**:
@Arelle/arelle
