### PR TITLE
Build without attestations

### DIFF
--- a/deploy/docker-build-push.sh
+++ b/deploy/docker-build-push.sh
@@ -4,9 +4,9 @@ set -eu
 v=${1?version}
 # Create HTTP_CACHE directory if it doesn't already exist.
 mkdir -p ./_HTTP_CACHE
-docker build --platform linux/amd64 -t frc-codex-lambda -f frc-codex-lambda.Dockerfile .
-docker build --platform linux/amd64 -t frc-codex-server -f frc-codex-server.Dockerfile .
-docker build --platform linux/amd64 -t frc-codex-support -f frc-codex-support.Dockerfile .
+docker build --platform linux/amd64 -t frc-codex-lambda -f frc-codex-lambda.Dockerfile --provenance=false .
+docker build --platform linux/amd64 -t frc-codex-server -f frc-codex-server.Dockerfile --provenance=false .
+docker build --platform linux/amd64 -t frc-codex-support -f frc-codex-support.Dockerfile --provenance=false .
 docker tag frc-codex-lambda 390403885523.dkr.ecr.eu-west-2.amazonaws.com/frc-codex/processor-lambda:$v
 docker tag frc-codex-server 390403885523.dkr.ecr.eu-west-2.amazonaws.com/frc-codex/server:$v
 docker tag frc-codex-support 390403885523.dkr.ecr.eu-west-2.amazonaws.com/frc-codex/support:$v

--- a/dev/env-build.sh
+++ b/dev/env-build.sh
@@ -4,16 +4,16 @@ set -e
 # Create HTTP_CACHE directory if it doesn't already exist.
 mkdir -p ./_HTTP_CACHE
 
-docker build -t frc-codex-lambda --platform linux/amd64 -f frc-codex-lambda.Dockerfile . &
+docker build -t frc-codex-lambda --platform linux/amd64 -f frc-codex-lambda.Dockerfile --provenance=false . &
 BUILD_LAMBDA_PID_1=$!
 
-docker build -t frc-codex-processor -f frc-codex-processor.Dockerfile . &
+docker build -t frc-codex-processor -f frc-codex-processor.Dockerfile --provenance=false . &
 BUILD_PROCESSOR_PID_2=$!
 
-docker build -t frc-codex-server -f frc-codex-server.Dockerfile . &
+docker build -t frc-codex-server -f frc-codex-server.Dockerfile --provenance=false . &
 BUILD_SERVER_PID_3=$!
 
-docker build -t frc-codex-support --platform linux/amd64 -f frc-codex-support.Dockerfile . &
+docker build -t frc-codex-support --platform linux/amd64 -f frc-codex-support.Dockerfile --provenance=false . &
 BUILD_SUPPORT_PID_4=$!
 
 wait $BUILD_LAMBDA_PID_1 $BUILD_PROCESSOR_PID_2 $BUILD_SERVER_PID_3 $BUILD_SUPPORT_PID_4


### PR DESCRIPTION
#### Reason for change
Newer buildx versions create and push an image index to AWS ECR which can't be directly deployed to lambda. By explicitly disabling attestations both new and older versions of buildx can be used.

#### Description of change
Explicitly disable attestations.

#### Steps to Test
* [x] Use the deploy scripts to build and deploy a new version of the service to AWS.

**review**:
@Arelle/arelle
